### PR TITLE
Refactor viclink [BC Break]

### DIFF
--- a/Bundle/CoreBundle/Command/LegacyLinkMigratorCommand.php
+++ b/Bundle/CoreBundle/Command/LegacyLinkMigratorCommand.php
@@ -1,0 +1,100 @@
+<?php
+namespace Victoire\Bundle\CoreBundle\Command;
+
+use Doctrine\ORM\Tools\DisconnectedClassMetadataFactory;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Victoire\Bundle\CoreBundle\Entity\Link;
+
+class LegacyLinkMigratorCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('victoire:legacy:linkMigrator')
+            ->setDescription('migrate old LinkTrait architecture into Link entity');
+    }
+
+    /**
+     * Read declared business entities and BusinessEntityPatternPages to generate their urls
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $progress = $this->getHelperSet()->get('progress');
+        $progress->setProgressCharacter('V');
+        $progress->setEmptyBarCharacter('-');
+
+        $entityManager = $this->getContainer()->get('doctrine.orm.entity_manager');
+
+        $cmf = new DisconnectedClassMetadataFactory();
+        $cmf->setEntityManager($entityManager);
+        $metadatas = $cmf->getAllMetadata();
+        $classes = [];
+        $output->writeln('<info>Parse every classes to know which ones are related to Link</info>');
+        $progress->start($output, count($metadatas));
+        foreach ($metadatas as $key => $metadata) {
+            $progress->advance();
+            if ($metadata->hasAssociation('link')) {
+                $association = $metadata->getAssociationMapping('link');
+                if ('Victoire\Bundle\CoreBundle\Entity\Link' === $association['targetEntity']) {
+                    $classes[] = $metadata;
+                }
+            }
+        }
+        $progress->finish();
+
+        $counter = 0;
+        if (count($classes)) {
+            $output->writeln('<info>Let\'s migrate</info>');
+            $progress->start($output, count($classes));
+            foreach ($classes as $class) {
+                $progress->advance();
+                //get the full universe of entities thanks to the entity repository
+                $objects = $entityManager->getRepository($class->name)->findAll();
+                foreach ($objects as $object) {
+                    if (!$object->hasLink()) {
+                        //Create a Link according to the legacy link trait properties
+                        $link = new Link();
+                        $object->setLink($link);
+                        //fill the values
+                        $link->setUrl($object->getUrl());
+                        $link->setTarget($object->getTarget());
+                        $link->setRoute($object->getRoute());
+                        $link->setRouteParameters($object->getRouteParameters());
+                        $link->setPage($object->getPage());
+                        $link->setLinkType($object->getLinkType());
+                        $link->setAttachedWidget($object->getAttachedWidget());
+                        $link->setAnalyticsTrackCode($object->getAnalyticsTrackCode());
+                        //reset legacy values
+                        $object->setUrl(null);
+                        $object->setRoute(null);
+                        $object->setRouteParameters(null);
+                        $object->setPage(null);
+                        $object->setAttachedWidget(null);
+                        $object->setAnalyticsTrackCode(null);
+                        //persist the new link and the relation
+                        $entityManager->persist($link);
+                        $entityManager->flush();
+                        $counter++;
+                    }
+                }
+            }
+            $progress->finish();
+            $output->writeln(sprintf('<comment>Ok, %s records migrated !</comment>', $counter));
+        }
+
+        if (0 == $counter) {
+            $output->writeln('<comment>Nothing to do...</comment>');
+        }
+    }
+}

--- a/Bundle/CoreBundle/Command/LegacyLinkMigratorCommand.php
+++ b/Bundle/CoreBundle/Command/LegacyLinkMigratorCommand.php
@@ -67,22 +67,16 @@ class LegacyLinkMigratorCommand extends ContainerAwareCommand
                         $link = new Link();
                         $object->setLink($link);
                         //fill the values
-                        $link->setUrl($object->getUrl());
-                        $link->setTarget($object->getTarget());
-                        $link->setRoute($object->getRoute());
-                        $link->setRouteParameters($object->getRouteParameters());
-                        $link->setPage($object->getPage());
-                        $link->setLinkType($object->getLinkType());
-                        $link->setAttachedWidget($object->getAttachedWidget());
-                        $link->setAnalyticsTrackCode($object->getAnalyticsTrackCode());
-                        //reset legacy values
-                        $object->setUrl(null);
-                        $object->setRoute(null);
-                        $object->setRouteParameters(null);
-                        $object->setPage(null);
-                        $object->setAttachedWidget(null);
-                        $object->setAnalyticsTrackCode(null);
+                        $link->setUrl($object->url);
+                        $link->setTarget($object->target);
+                        $link->setRoute($object->route);
+                        $link->setRouteParameters($object->routeParameters);
+                        $link->setPage($object->page);
+                        $link->setLinkType($object->linkType);
+                        $link->setAttachedWidget($object->attachedWidget);
+                        $link->setAnalyticsTrackCode($object->analyticsTrackCode);
                         //persist the new link and the relation
+                        $entityManager->persist($object);
                         $entityManager->persist($link);
                         $entityManager->flush();
                         $counter++;

--- a/Bundle/CoreBundle/Entity/Link.php
+++ b/Bundle/CoreBundle/Entity/Link.php
@@ -81,7 +81,7 @@ class Link
      */
     protected $analyticsTrackCode;
 
-    protected $linkParameters;
+    protected $parameters;
 
     /**
      * Get id
@@ -106,9 +106,9 @@ class Link
         return $this;
     }
 
-    public function getLinkParameters()
+    public function getParameters()
     {
-        return $this->linkParameters = array(
+        return $this->parameters = array(
             'linkType'           => $this->linkType,
             'url'                => $this->url,
             'page'               => $this->page,

--- a/Bundle/CoreBundle/Entity/Link.php
+++ b/Bundle/CoreBundle/Entity/Link.php
@@ -1,0 +1,354 @@
+<?php
+
+namespace Victoire\Bundle\CoreBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Victoire\Bundle\PageBundle\Entity\Page;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\ExecutionContextInterface;
+
+/**
+ * Victoire Link
+ *
+ * @ORM\Entity
+ * @ORM\Table("vic_link")
+ */
+class Link
+{
+    use \Gedmo\Timestampable\Traits\TimestampableEntity;
+
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="url", type="string", length=255, nullable=true)
+     */
+    protected $url;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="target", type="string", length=10, nullable=true)
+     */
+    protected $target = "_parent";
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Victoire\Bundle\PageBundle\Entity\BasePage")
+     * @ORM\JoinColumn(name="attached_page_id", referencedColumnName="id", onDelete="cascade", nullable=true)
+     */
+    protected $page;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Victoire\Bundle\WidgetBundle\Entity\Widget")
+     * @ORM\JoinColumn(name="attached_widget_id", referencedColumnName="id", onDelete="cascade", nullable=true)
+     */
+    protected $attachedWidget;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="route", type="string", length=55, nullable=true)
+     */
+    protected $route;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="route_parameters", type="array", nullable=true)
+     */
+    protected $routeParameters = array();
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="link_type", type="string", length=255, nullable=true)
+     */
+    protected $linkType = "none";
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="analytics_track_code", type="text", nullable=true)
+     */
+    protected $analyticsTrackCode;
+
+    protected $linkParameters;
+
+    /**
+     * Get id
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set id
+     * @param string $id
+     *
+     * @return $this
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getLinkParameters()
+    {
+        return $this->linkParameters = array(
+            'linkType'           => $this->linkType,
+            'url'                => $this->url,
+            'page'               => $this->page,
+            'route'              => $this->route,
+            'routeParameters'    => $this->routeParameters,
+            'attachedWidget'     => $this->attachedWidget,
+            'target'             => $this->target,
+            'analyticsTrackCode' => $this->analyticsTrackCode,
+        );
+    }
+
+    /**
+     * Set url
+     *
+     * @param string $url
+     *
+     * @return LinkTrait
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * Get url
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * Set target
+     *
+     * @param string $target
+     *
+     * @return LinkTrait
+     */
+    public function setTarget($target)
+    {
+        $this->target = $target;
+
+        return $this;
+    }
+
+    /**
+     * Get target
+     *
+     * @return string
+     */
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
+     * Set route
+     *
+     * @param string $route
+     *
+     * @return LinkTrait
+     */
+    public function setRoute($route)
+    {
+        $this->route = $route;
+
+        return $this;
+    }
+
+    /**
+     * Get route
+     *
+     * @return string
+     */
+    public function getRoute()
+    {
+        return $this->route;
+    }
+
+    /**
+     * Set routeParameters
+     *
+     * @param array $routeParameters
+     *
+     * @return LinkTrait
+     */
+    public function setRouteParameters($routeParameters)
+    {
+        $this->routeParameters = $routeParameters;
+
+        return $this;
+    }
+
+    /**
+     * Get routeParameters
+     *
+     * @return array
+     */
+    public function getRouteParameters()
+    {
+        return $this->routeParameters;
+    }
+
+    /**
+     * Set page
+     * @param \Victoire\Bundle\PageBundle\Entity\Page $page
+     *
+     * @return LinkTrait
+     */
+    public function setPage($page = null)
+    {
+        $this->page = $page;
+
+        return $this;
+    }
+
+    /**
+     * Get page
+     *
+     * @return \Victoire\Bundle\PageBundle\Entity\BasePage
+     */
+    public function getPage()
+    {
+        return $this->page;
+    }
+
+    /**
+     * Set linkType
+     *
+     * @param string $linkType
+     *
+     * @return LinkTrait
+     */
+    public function setLinkType($linkType)
+    {
+        $this->linkType = $linkType;
+
+        return $this;
+    }
+
+    /**
+     * Get linkType
+     *
+     * @return string
+     */
+    public function getLinkType()
+    {
+        return $this->linkType;
+    }
+    /**
+     * Get attachedWidget
+     *
+     * @return string
+     */
+    public function getAttachedWidget()
+    {
+        return $this->attachedWidget;
+    }
+
+    /**
+     * Set attachedWidget
+     *
+     * @param string $attachedWidget
+     *
+     * @return $this
+     */
+    public function setAttachedWidget($attachedWidget)
+    {
+        $this->attachedWidget = $attachedWidget;
+
+        return $this;
+    }
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata)
+    {
+        $metadata->addConstraint(new Assert\Callback('checkLink'));
+    }
+
+    /**
+     * undocumented function
+     *
+     * @return void
+     * @author
+     **/
+    public function checkLink(ExecutionContextInterface $context)
+    {
+        $violation = false;
+        // check if the name is actually a fake name
+        switch ($this->getLinkType()) {
+            case 'page':
+            $violation = $this->getPage() == null;
+                break;
+            case 'route':
+            $violation = $this->getRoute() == null;
+                break;
+            case 'url':
+            $violation = $this->getUrl() == null;
+                break;
+            case 'attachedWidget':
+            $violation = $this->getAttachedWidget() == null;
+                break;
+            default:
+                break;
+        }
+
+        if ($violation) {
+            $context->addViolationAt(
+                'firstName',
+                'validator.link.error.message.'.$this->getLinkType().'Missing',
+                array(),
+                null
+            );
+        }
+    }
+
+    /**
+     * Get analyticsTrackCode
+     *
+     * @return string
+     */
+    public function getAnalyticsTrackCode()
+    {
+        return $this->analyticsTrackCode;
+    }
+
+    /**
+     * Set analyticsTrackCode
+     *
+     * @param string $analyticsTrackCode
+     *
+     * @return $this
+     */
+    public function setAnalyticsTrackCode($analyticsTrackCode)
+    {
+        $this->analyticsTrackCode = $analyticsTrackCode;
+
+        return $this;
+    }
+}

--- a/Bundle/WidgetBundle/Entity/Traits/LinkTrait.php
+++ b/Bundle/WidgetBundle/Entity/Traits/LinkTrait.php
@@ -1,9 +1,7 @@
 <?php
 namespace Victoire\Bundle\WidgetBundle\Entity\Traits;
 
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\ExecutionContextInterface;
 
 /**
  * Link trait adds fields to create a link to a page, widget, url or route
@@ -23,6 +21,7 @@ trait LinkTrait
      *
      * @ORM\Column(name="url", type="string", length=255, nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
+     * \ will be removed in next major version
      */
     public $url;
 
@@ -31,6 +30,7 @@ trait LinkTrait
      *
      * @ORM\Column(name="target", type="string", length=10, nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
+     * \ will be removed in next major version
      */
     public $target;
 
@@ -38,6 +38,7 @@ trait LinkTrait
      * @ORM\ManyToOne(targetEntity="Victoire\Bundle\PageBundle\Entity\BasePage")
      * @ORM\JoinColumn(name="attached_page_id", referencedColumnName="id", onDelete="cascade", nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
+     * \ will be removed in next major version
      */
     public $page;
 
@@ -45,6 +46,7 @@ trait LinkTrait
      * @ORM\ManyToOne(targetEntity="Victoire\Bundle\WidgetBundle\Entity\Widget")
      * @ORM\JoinColumn(name="attached_widget_id", referencedColumnName="id", onDelete="cascade", nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
+     * \ will be removed in next major version
      */
     public $attachedWidget;
 
@@ -53,6 +55,7 @@ trait LinkTrait
      *
      * @ORM\Column(name="route", type="string", length=55, nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
+     * \ will be removed in next major version
      */
     public $route;
 
@@ -61,6 +64,7 @@ trait LinkTrait
      *
      * @ORM\Column(name="route_parameters", type="array", nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
+     * \ will be removed in next major version
      */
     public $routeParameters = array();
 
@@ -69,6 +73,7 @@ trait LinkTrait
      *
      * @ORM\Column(name="link_type", type="string", length=255, nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
+     * \ will be removed in next major version
      */
     public $linkType;
 
@@ -77,263 +82,9 @@ trait LinkTrait
      *
      * @ORM\Column(name="analytics_track_code", type="text", nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
+     * \ will be removed in next major version
      */
     public $analyticsTrackCode;
-
-    public $linkParameters;
-
-    /**
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     */
-    public function getLinkParameters()
-    {
-        return $this->getLink()->getParameters();
-    }
-
-    /**
-     * Set url
-     *
-     * @param string $url
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrait
-     */
-    public function setUrl($url)
-    {
-        return $this->getLink()->setUrl($url);
-    }
-
-    /**
-     * Get url
-     *
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return string
-     */
-    public function getUrl()
-    {
-        return $this->getLink()->getUrl();
-    }
-
-    /**
-     * Set target
-     *
-     * @param string $target
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrait
-     */
-    public function setTarget($target)
-    {
-        return $this->getLink()->setTarget($target);
-    }
-
-    /**
-     * Get target
-     *
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return string
-     */
-    public function getTarget()
-    {
-        return $this->getLink()->getTarget();
-    }
-
-    /**
-     * Set route
-     *
-     * @param string $route
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrait
-     */
-    public function setRoute($route)
-    {
-        return $this->getLink()->setRoute($route);
-    }
-
-    /**
-     * Get route
-     *
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return string
-     */
-    public function getRoute()
-    {
-        return $this->getLink()->getRoute();
-    }
-
-    /**
-     * Set routeParameters
-     *
-     * @param array $routeParameters
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrait
-     */
-    public function setRouteParameters($routeParameters)
-    {
-        return $this->getLink()->setRouteParameters($routeParameters);
-    }
-
-    /**
-     * Get routeParameters
-     *
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return array
-     */
-    public function getRouteParameters()
-    {
-        return $this->getLink()->getRouteParameters();
-    }
-
-    /**
-     * Set page
-     * @param \Victoire\Bundle\PageBundle\Entity\Page $page
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrait
-     */
-    public function setPage($page = null)
-    {
-        return $this->getLink()->setPage($page);
-    }
-
-    /**
-     * Get page
-     *
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return \Victoire\Bundle\PageBundle\Entity\BasePage
-     */
-    public function getPage()
-    {
-        return $this->getLink()->getPage();
-    }
-
-    /**
-     * Set linkType
-     *
-     * @param string $linkType
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrait
-     */
-    public function setLinkType($linkType)
-    {
-        return $this->getLink()->setLinkType();
-    }
-
-    /**
-     * Get linkType
-     *
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return string
-     */
-    public function getLinkType()
-    {
-        return $this->getLink()->getLinkType();
-    }
-    /**
-     * Get attachedWidget
-     *
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return string
-     */
-    public function getAttachedWidget()
-    {
-        return $this->getLink()->getAttachedWidget();
-    }
-
-    /**
-     * Set attachedWidget
-     *
-     * @param string $attachedWidget
-     *
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return $this
-     */
-    public function setAttachedWidget($attachedWidget)
-    {
-        return $this->getLink()->setAttachedWidget($attachedWidget);
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata)
-    {
-        $metadata->addConstraint(new Assert\Callback('checkLink'));
-    }
-
-    /**
-     * undocumented function
-     *
-     * @return void
-     * @author
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     **/
-    public function checkLink(ExecutionContextInterface $context)
-    {
-        $violation = false;
-        // check if the name is actually a fake name
-        switch ($this->getLink()->getLinkType()) {
-            case 'page':
-            $violation = $this->getLink()->getPage() == null;
-                break;
-            case 'route':
-            $violation = $this->getLink()->getRoute() == null;
-                break;
-            case 'url':
-            $violation = $this->getLink()->getUrl() == null;
-                break;
-            case 'attachedWidget':
-            $violation = $this->getLink()->getAttachedWidget() == null;
-                break;
-            default:
-                break;
-        }
-
-        if ($violation) {
-            $context->addViolationAt(
-                'firstName',
-                'validator.link.error.message.'.$this->getLink()->getLinkType().'Missing',
-                array(),
-                null
-            );
-        }
-    }
-
-    /**
-     * Get analyticsTrackCode
-     *
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return string
-     */
-    public function getAnalyticsTrackCode()
-    {
-        return $this->getLink()->getAnalyticsTrackCode();
-    }
-
-    /**
-     * Set analyticsTrackCode
-     *
-     * @param string $analyticsTrackCode
-     *
-     *
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return $this
-     */
-    public function setAnalyticsTrackCode($analyticsTrackCode)
-    {
-        return $this->getLink()->setAnalyticsTrackCode($analyticsTrackCode);
-    }
 
     /**
      * Has link

--- a/Bundle/WidgetBundle/Entity/Traits/LinkTrait.php
+++ b/Bundle/WidgetBundle/Entity/Traits/LinkTrait.php
@@ -13,7 +13,8 @@ use Symfony\Component\Validator\ExecutionContextInterface;
 trait LinkTrait
 {
     /**
-     * @ORM\OneToOne(targetEntity="Victoire\Bundle\CoreBundle\Entity\Link")
+     * @ORM\OneToOne(targetEntity="Victoire\Bundle\CoreBundle\Entity\Link", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(name="link_id", referencedColumnName="id", nullable=true, onDelete="SET NULL")
      **/
     protected $link;
 
@@ -23,7 +24,7 @@ trait LinkTrait
      * @ORM\Column(name="url", type="string", length=255, nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
      */
-    protected $url;
+    public $url;
 
     /**
      * @var string
@@ -31,21 +32,21 @@ trait LinkTrait
      * @ORM\Column(name="target", type="string", length=10, nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
      */
-    protected $target;
+    public $target;
 
     /**
      * @ORM\ManyToOne(targetEntity="Victoire\Bundle\PageBundle\Entity\BasePage")
      * @ORM\JoinColumn(name="attached_page_id", referencedColumnName="id", onDelete="cascade", nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
      */
-    protected $page;
+    public $page;
 
     /**
      * @ORM\ManyToOne(targetEntity="Victoire\Bundle\WidgetBundle\Entity\Widget")
      * @ORM\JoinColumn(name="attached_widget_id", referencedColumnName="id", onDelete="cascade", nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
      */
-    protected $attachedWidget;
+    public $attachedWidget;
 
     /**
      * @var string
@@ -53,7 +54,7 @@ trait LinkTrait
      * @ORM\Column(name="route", type="string", length=55, nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
      */
-    protected $route;
+    public $route;
 
     /**
      * @var string
@@ -61,7 +62,7 @@ trait LinkTrait
      * @ORM\Column(name="route_parameters", type="array", nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
      */
-    protected $routeParameters = array();
+    public $routeParameters = array();
 
     /**
      * @var string
@@ -69,7 +70,7 @@ trait LinkTrait
      * @ORM\Column(name="link_type", type="string", length=255, nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
      */
-    protected $linkType;
+    public $linkType;
 
     /**
      * @var string
@@ -77,9 +78,9 @@ trait LinkTrait
      * @ORM\Column(name="analytics_track_code", type="text", nullable=true)
      * @deprecated please run the victoire:legacy:linkMigrator command
      */
-    protected $analyticsTrackCode;
+    public $analyticsTrackCode;
 
-    protected $linkParameters;
+    public $linkParameters;
 
     /**
      *
@@ -88,7 +89,7 @@ trait LinkTrait
      */
     public function getLinkParameters()
     {
-        return $this->getLink()->getLinkParameters();
+        return $this->getLink()->getParameters();
     }
 
     /**
@@ -97,9 +98,7 @@ trait LinkTrait
      * @param string $url
      *
      * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrai
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     *                  t
+     * @return LinkTrait
      */
     public function setUrl($url)
     {
@@ -124,9 +123,7 @@ trait LinkTrait
      * @param string $target
      *
      * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrai
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     *                  t
+     * @return LinkTrait
      */
     public function setTarget($target)
     {
@@ -151,9 +148,7 @@ trait LinkTrait
      * @param string $route
      *
      * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrai
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     *                  t
+     * @return LinkTrait
      */
     public function setRoute($route)
     {
@@ -178,9 +173,7 @@ trait LinkTrait
      * @param array $routeParameters
      *
      * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrai
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     *                  t
+     * @return LinkTrait
      */
     public function setRouteParameters($routeParameters)
     {
@@ -204,9 +197,7 @@ trait LinkTrait
      * @param \Victoire\Bundle\PageBundle\Entity\Page $page
      *
      * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrai
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     *                  t
+     * @return LinkTrait
      */
     public function setPage($page = null)
     {
@@ -231,9 +222,7 @@ trait LinkTrait
      * @param string $linkType
      *
      * @deprecated please run the victoire:legacy:linkMigrator command
-     * @return LinkTrai
-     * @deprecated please run the victoire:legacy:linkMigrator command
-     *                  t
+     * @return LinkTrait
      */
     public function setLinkType($linkType)
     {
@@ -286,9 +275,8 @@ trait LinkTrait
      * undocumented function
      *
      * @return void
-     * @autho
+     * @author
      * @deprecated please run the victoire:legacy:linkMigrator command
-     *              r
      **/
     public function checkLink(ExecutionContextInterface $context)
     {

--- a/Bundle/WidgetBundle/Entity/Traits/LinkTrait.php
+++ b/Bundle/WidgetBundle/Entity/Traits/LinkTrait.php
@@ -12,30 +12,38 @@ use Symfony\Component\Validator\ExecutionContextInterface;
  */
 trait LinkTrait
 {
+    /**
+     * @ORM\OneToOne(targetEntity="Victoire\Bundle\CoreBundle\Entity\Link")
+     **/
+    protected $link;
 
     /**
      * @var string
      *
      * @ORM\Column(name="url", type="string", length=255, nullable=true)
+     * @deprecated please run the victoire:legacy:linkMigrator command
      */
     protected $url;
 
     /**
      * @var string
      *
-     * @ORM\Column(name="target", type="string", length=10)
+     * @ORM\Column(name="target", type="string", length=10, nullable=true)
+     * @deprecated please run the victoire:legacy:linkMigrator command
      */
     protected $target;
 
     /**
      * @ORM\ManyToOne(targetEntity="Victoire\Bundle\PageBundle\Entity\BasePage")
      * @ORM\JoinColumn(name="attached_page_id", referencedColumnName="id", onDelete="cascade", nullable=true)
+     * @deprecated please run the victoire:legacy:linkMigrator command
      */
     protected $page;
 
     /**
      * @ORM\ManyToOne(targetEntity="Victoire\Bundle\WidgetBundle\Entity\Widget")
      * @ORM\JoinColumn(name="attached_widget_id", referencedColumnName="id", onDelete="cascade", nullable=true)
+     * @deprecated please run the victoire:legacy:linkMigrator command
      */
     protected $attachedWidget;
 
@@ -43,6 +51,7 @@ trait LinkTrait
      * @var string
      *
      * @ORM\Column(name="route", type="string", length=55, nullable=true)
+     * @deprecated please run the victoire:legacy:linkMigrator command
      */
     protected $route;
 
@@ -50,13 +59,15 @@ trait LinkTrait
      * @var string
      *
      * @ORM\Column(name="route_parameters", type="array", nullable=true)
+     * @deprecated please run the victoire:legacy:linkMigrator command
      */
     protected $routeParameters = array();
 
     /**
      * @var string
      *
-     * @ORM\Column(name="link_type", type="string", length=255)
+     * @ORM\Column(name="link_type", type="string", length=255, nullable=true)
+     * @deprecated please run the victoire:legacy:linkMigrator command
      */
     protected $linkType;
 
@@ -64,23 +75,20 @@ trait LinkTrait
      * @var string
      *
      * @ORM\Column(name="analytics_track_code", type="text", nullable=true)
+     * @deprecated please run the victoire:legacy:linkMigrator command
      */
     protected $analyticsTrackCode;
 
     protected $linkParameters;
 
+    /**
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     */
     public function getLinkParameters()
     {
-        return $this->linkParameters = array(
-            'linkType'           => $this->linkType,
-            'url'                => $this->url,
-            'page'               => $this->page,
-            'route'              => $this->route,
-            'routeParameters'    => $this->routeParameters,
-            'attachedWidget'     => $this->attachedWidget,
-            'target'             => $this->target,
-            'analyticsTrackCode' => $this->analyticsTrackCode,
-        );
+        return $this->getLink()->getLinkParameters();
     }
 
     /**
@@ -88,23 +96,26 @@ trait LinkTrait
      *
      * @param string $url
      *
-     * @return LinkTrait
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     * @return LinkTrai
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     *                  t
      */
     public function setUrl($url)
     {
-        $this->url = $url;
-
-        return $this;
+        return $this->getLink()->setUrl($url);
     }
 
     /**
      * Get url
      *
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
      * @return string
      */
     public function getUrl()
     {
-        return $this->url;
+        return $this->getLink()->getUrl();
     }
 
     /**
@@ -112,23 +123,26 @@ trait LinkTrait
      *
      * @param string $target
      *
-     * @return LinkTrait
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     * @return LinkTrai
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     *                  t
      */
     public function setTarget($target)
     {
-        $this->target = $target;
-
-        return $this;
+        return $this->getLink()->setTarget($target);
     }
 
     /**
      * Get target
      *
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
      * @return string
      */
     public function getTarget()
     {
-        return $this->target;
+        return $this->getLink()->getTarget();
     }
 
     /**
@@ -136,23 +150,26 @@ trait LinkTrait
      *
      * @param string $route
      *
-     * @return LinkTrait
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     * @return LinkTrai
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     *                  t
      */
     public function setRoute($route)
     {
-        $this->route = $route;
-
-        return $this;
+        return $this->getLink()->setRoute($route);
     }
 
     /**
      * Get route
      *
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
      * @return string
      */
     public function getRoute()
     {
-        return $this->route;
+        return $this->getLink()->getRoute();
     }
 
     /**
@@ -160,46 +177,52 @@ trait LinkTrait
      *
      * @param array $routeParameters
      *
-     * @return LinkTrait
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     * @return LinkTrai
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     *                  t
      */
     public function setRouteParameters($routeParameters)
     {
-        $this->routeParameters = $routeParameters;
-
-        return $this;
+        return $this->getLink()->setRouteParameters($routeParameters);
     }
 
     /**
      * Get routeParameters
      *
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
      * @return array
      */
     public function getRouteParameters()
     {
-        return $this->routeParameters;
+        return $this->getLink()->getRouteParameters();
     }
 
     /**
      * Set page
      * @param \Victoire\Bundle\PageBundle\Entity\Page $page
      *
-     * @return LinkTrait
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     * @return LinkTrai
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     *                  t
      */
     public function setPage($page = null)
     {
-        $this->page = $page;
-
-        return $this;
+        return $this->getLink()->setPage($page);
     }
 
     /**
      * Get page
      *
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
      * @return \Victoire\Bundle\PageBundle\Entity\BasePage
      */
     public function getPage()
     {
-        return $this->page;
+        return $this->getLink()->getPage();
     }
 
     /**
@@ -207,32 +230,37 @@ trait LinkTrait
      *
      * @param string $linkType
      *
-     * @return LinkTrait
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     * @return LinkTrai
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     *                  t
      */
     public function setLinkType($linkType)
     {
-        $this->linkType = $linkType;
-
-        return $this;
+        return $this->getLink()->setLinkType();
     }
 
     /**
      * Get linkType
      *
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
      * @return string
      */
     public function getLinkType()
     {
-        return $this->linkType;
+        return $this->getLink()->getLinkType();
     }
     /**
      * Get attachedWidget
      *
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
      * @return string
      */
     public function getAttachedWidget()
     {
-        return $this->attachedWidget;
+        return $this->getLink()->getAttachedWidget();
     }
 
     /**
@@ -240,13 +268,13 @@ trait LinkTrait
      *
      * @param string $attachedWidget
      *
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
      * @return $this
      */
     public function setAttachedWidget($attachedWidget)
     {
-        $this->attachedWidget = $attachedWidget;
-
-        return $this;
+        return $this->getLink()->setAttachedWidget($attachedWidget);
     }
 
     public static function loadValidatorMetadata(ClassMetadata $metadata)
@@ -258,24 +286,26 @@ trait LinkTrait
      * undocumented function
      *
      * @return void
-     * @author
+     * @autho
+     * @deprecated please run the victoire:legacy:linkMigrator command
+     *              r
      **/
     public function checkLink(ExecutionContextInterface $context)
     {
         $violation = false;
         // check if the name is actually a fake name
-        switch ($this->getLinkType()) {
+        switch ($this->getLink()->getLinkType()) {
             case 'page':
-            $violation = $this->getPage() == null;
+            $violation = $this->getLink()->getPage() == null;
                 break;
             case 'route':
-            $violation = $this->getRoute() == null;
+            $violation = $this->getLink()->getRoute() == null;
                 break;
             case 'url':
-            $violation = $this->getUrl() == null;
+            $violation = $this->getLink()->getUrl() == null;
                 break;
             case 'attachedWidget':
-            $violation = $this->getAttachedWidget() == null;
+            $violation = $this->getLink()->getAttachedWidget() == null;
                 break;
             default:
                 break;
@@ -284,7 +314,7 @@ trait LinkTrait
         if ($violation) {
             $context->addViolationAt(
                 'firstName',
-                'validator.link.error.message.'.$this->getLinkType().'Missing',
+                'validator.link.error.message.'.$this->getLink()->getLinkType().'Missing',
                 array(),
                 null
             );
@@ -294,11 +324,13 @@ trait LinkTrait
     /**
      * Get analyticsTrackCode
      *
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
      * @return string
      */
     public function getAnalyticsTrackCode()
     {
-        return $this->analyticsTrackCode;
+        return $this->getLink()->getAnalyticsTrackCode();
     }
 
     /**
@@ -306,11 +338,44 @@ trait LinkTrait
      *
      * @param string $analyticsTrackCode
      *
+     *
+     * @deprecated please run the victoire:legacy:linkMigrator command
      * @return $this
      */
     public function setAnalyticsTrackCode($analyticsTrackCode)
     {
-        $this->analyticsTrackCode = $analyticsTrackCode;
+        return $this->getLink()->setAnalyticsTrackCode($analyticsTrackCode);
+    }
+
+    /**
+     * Has link
+     *
+     * @return boolean
+     */
+    public function hasLink()
+    {
+        return $this->link ? true : false;
+    }
+
+    /**
+     * Get link
+     *
+     * @return string
+     */
+    public function getLink()
+    {
+        return $this->link;
+    }
+
+    /**
+     * Set link
+     * @param string $link
+     *
+     * @return $this
+     */
+    public function setLink($link)
+    {
+        $this->link = $link;
 
         return $this;
     }


### PR DESCRIPTION
## This PR breaks BC and expects from you to :

- to run the following command :

```php
    console victoire:legacy:linkMigrator
```

- to update every version of widget which use the LinkTrait 

```php
    composer update victoire/slider-widget victoire/button-widget victoire/menu-widget
```

If you used LinkTrait in your own widgets, you need to do these things:

- replace linkParameters by link.parameters