### PR TITLE
Utilisation de asset plutôt qu'un lien direct

### DIFF
--- a/Bundle/UserBundle/Resources/views/layout.html.twig
+++ b/Bundle/UserBundle/Resources/views/layout.html.twig
@@ -7,7 +7,7 @@
 
         <div id="vic-login-content">
             <div class="vic-text-center">
-                <img id="vic-login-logo" src="/bundles/victoirecore/images/login/logo.svg" alt="Logo Victoire">
+                <img id="vic-login-logo" src="{{ asset('bundles/victoirecore/images/login/logo.svg') }}" alt="Logo Victoire">
             </div>
 
             <div id="vic-login-form">


### PR DESCRIPTION
Pour prévenir d'une erreur 404 sur le logo si on utilise victoire avec un sous-répetoire, on utilise asset() plutôt que le lien direct.