### PR TITLE
Use patternId instead of viewId for pattern entities in ViewHelper

### DIFF
--- a/Bundle/CoreBundle/Helper/ViewHelper.php
+++ b/Bundle/CoreBundle/Helper/ViewHelper.php
@@ -248,7 +248,7 @@ class ViewHelper
                                 'url'             => $page->getUrl(),
                                 'name'             => $page->getName(),
                                 'locale'          => $page->getLocale(),
-                                'viewId'          => $page->getTemplate()->getId(),
+                                'patternId'       => $page->getTemplate()->getId(),
                                 'entityId'        => $entity->getId(),
                                 'entityNamespace' => $this->em->getClassMetadata(get_class($entity))->name,
                                 'viewNamespace'   => $this->em->getClassMetadata(get_class($view))->name,


### PR DESCRIPTION
Lorsqu'on utilisait la méthode vic_business_link, c'est le paramètre viewId qui était recherche dans le fichier viewReferences.xml alors qu'il faut utiliser le paramètre patternId pour les pattern entities