### PR TITLE
store main current page in CurrentViewHelper in order to reuse it for…

### DIFF
--- a/Bundle/CoreBundle/Helper/CurrentViewHelper.php
+++ b/Bundle/CoreBundle/Helper/CurrentViewHelper.php
@@ -10,6 +10,7 @@ use Victoire\Bundle\CoreBundle\Entity\View;
 class CurrentViewHelper
 {
     protected $currentView;
+    protected $mainCurrentView;
 
     /**
      * Get currentView
@@ -19,6 +20,15 @@ class CurrentViewHelper
     public function getCurrentView()
     {
         return $this->currentView;
+    }
+    /**
+     * Get mainCurrentView
+     *
+     * @return View
+     */
+    public function getMainCurrentView()
+    {
+        return $this->mainCurrentView;
     }
 
     /**
@@ -30,6 +40,9 @@ class CurrentViewHelper
      */
     public function setCurrentView(View $currentView)
     {
+        if ($this->currentView == null) {
+            $this->mainCurrentView = clone $currentView;
+        }
         $this->currentView = $currentView;
 
         return $this;

--- a/Bundle/CoreBundle/Resources/views/layout.html.twig
+++ b/Bundle/CoreBundle/Resources/views/layout.html.twig
@@ -48,7 +48,7 @@
 
         {% if view is defined %}
         <script type="text/javascript">
-            var viewReferenceId = '{{ view.reference.id }}';
+            var viewReferenceId = '{{ vic_current_page_reference() }}';
         </script>
         {{ render_hinclude(controller('VictoireAnalyticsBundle:BrowseEvent:track', {'viewReferenceId': view.reference.id, 'referer': app.request.headers.get('referer')})) }}
         {% endif %}

--- a/Bundle/PageBundle/Resources/config/services.yml
+++ b/Bundle/PageBundle/Resources/config/services.yml
@@ -101,5 +101,6 @@ services:
             - "@victoire_business_entity_page.business_entity_page_helper"
             - "@router"
             - "@victoire_page.page_helper"
+            - "@victoire_core.current_view"
         tags:
             - { name: twig.extension }

--- a/Bundle/PageBundle/Twig/Extension/PageExtension.php
+++ b/Bundle/PageBundle/Twig/Extension/PageExtension.php
@@ -5,6 +5,7 @@ namespace Victoire\Bundle\PageBundle\Twig\Extension;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Victoire\Bundle\BusinessEntityPageBundle\Entity\BusinessEntityPagePattern;
 use Victoire\Bundle\BusinessEntityPageBundle\Helper\BusinessEntityPageHelper;
+use Victoire\Bundle\CoreBundle\Helper\CurrentViewHelper;
 use Victoire\Bundle\PageBundle\Entity\BasePage;
 use Victoire\Bundle\PageBundle\Helper\PageHelper;
 
@@ -21,14 +22,16 @@ class PageExtension extends \Twig_Extension
      * Constructor
      *
      * @param BusinessEntityPageHelper $businessEntityPagePatternHelper
-     * @param Router                   $router
-     * @param PageHelper               $pageHelper
+     * @param Router $router
+     * @param PageHelper $pageHelper
+     * @param CurrentViewHelper $currentViewHelper
      */
-    public function __construct(BusinessEntityPageHelper $businessEntityPagePatternHelper, Router $router, PageHelper $pageHelper)
+    public function __construct(BusinessEntityPageHelper $businessEntityPagePatternHelper, Router $router, PageHelper $pageHelper, CurrentViewHelper $currentViewHelper)
     {
         $this->businessEntityPagePatternHelper = $businessEntityPagePatternHelper;
         $this->router = $router;
         $this->pageHelper = $pageHelper;
+        $this->currentViewHelper = $currentViewHelper;
     }
 
     /**
@@ -39,6 +42,7 @@ class PageExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
+            new \Twig_SimpleFunction('vic_current_page_reference', array($this, 'victoireCurrentPageReference')),
             'cms_page_business_page_pattern_sitemap' => new \Twig_Function_Method($this, 'cmsPageBusinessPagePatternSiteMap', array('is_safe' => array('html'))),
         );
     }
@@ -167,5 +171,12 @@ class PageExtension extends \Twig_Extension
         }
 
         return $urls;
+    }
+
+    public function victoireCurrentPageReference()
+    {
+        $currentView = $this->currentViewHelper;
+
+        return $currentView->getMainCurrentView()->getReference()['id'];
     }
 }


### PR DESCRIPTION
… javascript viewReferenceId without possibly changes from widgets in the page

/!\ When updating victoire, you should change the following in your project layout:

From:
```javascript
    <script type="text/javascript">
        var viewReferenceId = '{{ view.reference.id }}';
    </script>
```
To:
```javascript
    <script type="text/javascript">
        var viewReferenceId = '{{ vic_current_page_reference() }}';
    </script>
```