### PR TITLE
fix update to regenerate correct references

### DIFF
--- a/Bundle/CoreBundle/Helper/ViewCacheHelper.php
+++ b/Bundle/CoreBundle/Helper/ViewCacheHelper.php
@@ -99,7 +99,7 @@ XML;
         /** @var ViewHelper $viewHelper */
         $viewHelper = $this->container->get('victoire_core.view_helper');
         $rootNode = $this->readCache();
-        $viewReference = $viewHelper->getViewReferenceByView($view, $entity);
+        $viewReference = $viewHelper->getViewReferenceByView($view);
         self::removeViewReference($rootNode, $viewReference);
         $itemNode = $rootNode->addChild('viewReference');
         foreach ($viewReference as $key => $value) {

--- a/Bundle/CoreBundle/Helper/ViewHelper.php
+++ b/Bundle/CoreBundle/Helper/ViewHelper.php
@@ -178,7 +178,7 @@ class ViewHelper
     public function getViewReferenceByView(View $view, $entity = null)
     {
         $viewReference = array(
-            'id'            => $this->viewCacheHelper->getViewReferenceId($view),
+            'id'            => $this->viewCacheHelper->getViewReferenceId($view, $entity),
             'locale'        => $view->getLocale(),
             'viewId'        => $view->getId(),
             'name'          => $view->getName(),


### PR DESCRIPTION
When i was creating a Business Entity, the cache regenerated was wrong. The method call from view cache helper rewrite Business entity page pattern with an entity id.