### PR TITLE
remove angular library from victoire-ngApp assetic injector

### DIFF
--- a/Bundle/CoreBundle/Resources/config/assetic_injector.json
+++ b/Bundle/CoreBundle/Resources/config/assetic_injector.json
@@ -12,7 +12,6 @@
             ],
             "victoire-ngApp":
             [
-                "https://ajax.googleapis.com/ajax/libs/angularjs/1.3.16/angular.min.js",
                 "http://code.angularjs.org/1.4.1/angular-sanitize.min.js",
                 "@VictoireCoreBundle/Resources/script/ngApp/app.js",
                 "@VictoireCoreBundle/Resources/script/ngApp/controllers/page/PageCtrl.js",

--- a/Bundle/CoreBundle/Resources/script/ngApp/app.js
+++ b/Bundle/CoreBundle/Resources/script/ngApp/app.js
@@ -1,4 +1,10 @@
-var ngApp = angular.module('ngApp', ["ngSanitize"]).
+if (window.ngDependencies == undefined) {
+    window.ngDependencies = [];
+}
+
+window.ngDependencies.push("ngSanitize");
+
+var ngApp = angular.module('ngApp', window.ngDependencies).
     config(function($interpolateProvider){$interpolateProvider.startSymbol('{[{').endSymbol('}]}');}).
     config(['$httpProvider', function($httpProvider) {
         $httpProvider.defaults.headers.common["X-Requested-With"] = 'XMLHttpRequest';

--- a/Bundle/CoreBundle/Resources/views/backendLayout.html.twig
+++ b/Bundle/CoreBundle/Resources/views/backendLayout.html.twig
@@ -15,6 +15,7 @@
 {% endblock body %}
 
 {% block foot_script %}
+    {{ parent() }}
 
     {% spaceless %}
         {% javascripts injector='victoire-edit, victoire-leftnavbar' %}

--- a/Bundle/CoreBundle/Resources/views/layout.html.twig
+++ b/Bundle/CoreBundle/Resources/views/layout.html.twig
@@ -19,6 +19,7 @@
         {% endjavascripts %}
         <!-- END HEAD_SCRIPT -->
         <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.16/angular.min.js"></script>
     {% endblock head_script %}
     {% block head_style %}
         <!-- HEAD_STYLE -->


### PR DESCRIPTION
we can now push extra dependancies in the ngApp with the window.ngDependancies array which is read when boostraped