### PR TITLE
Call get method to use really default value

### DIFF
--- a/Bundle/BusinessEntityBundle/Reader/BusinessEntityCacheReader.php
+++ b/Bundle/BusinessEntityBundle/Reader/BusinessEntityCacheReader.php
@@ -111,14 +111,14 @@ class BusinessEntityCacheReader
      */
     protected function fetch($key)
     {
-        $results = $this->cache->fetch($key, null);
+        $results = $this->cache->get($key, null);
 
         if (!$results) {
             //Reparse all entities to find some @VIC Annotation
             foreach ($this->driver->getAllClassNames() as $className) {
                 $this->driver->parse(new \ReflectionClass($className));
             }
-            $results = $this->cache->fetch($key, []);
+            $results = $this->cache->get($key, []);
         }
 
         return $results;


### PR DESCRIPTION
Fetch method on cache object doesn't accept default value : get method, yes

If key is not found, $results = false and somes methods after will crash like it : https://github.com/Victoire/victoire/blob/master/Bundle/BusinessEntityBundle/Helper/BusinessEntityHelper.php#L112
