### PR TITLE
Hotfix/widgetmap migration issue

### DIFF
--- a/Bundle/WidgetMapBundle/Command/WidgetMapMigrationCommand.php
+++ b/Bundle/WidgetMapBundle/Command/WidgetMapMigrationCommand.php
@@ -88,6 +88,7 @@ class WidgetMapMigrationCommand extends ContainerAwareCommand
         /** @var View $view */
         foreach ($views as $view) {
             $this->getContainer()->get('victoire_widget_map.builder')->build($view);
+
             $widgets = [];
             foreach ($view->getWidgets() as $widget) {
                 $widgets[$widget->getId()] = $widget;
@@ -186,7 +187,7 @@ class WidgetMapMigrationCommand extends ContainerAwareCommand
                                 $supplicantWidget = $widgetRepo->find($_oldWidgetMap['widgetId']);
                                 $replacedWidgetView = $replacedWidget->getView();
                                 $this->getContainer()->get('victoire_widget_map.builder')->build($replacedWidgetView);
-                                $replacedWidgetMap = $replacedWidgetView->getWidgetMapByWidget($replacedWidget);
+                                $replacedWidgetMap = WidgetMapHelper::getWidgetMapByWidgetAndView($replacedWidget, $replacedWidgetView);
                                 // If replaced widgetMap does not exists, this is not an overwrite but a create
                                 if ($replacedWidgetMap) {
                                     $output->writeln('has replacedWidgetMap');
@@ -219,7 +220,7 @@ class WidgetMapMigrationCommand extends ContainerAwareCommand
                             if ($deletedWidgetMap) {
                                 $replacedWidgetView = $replacedWidget->getView();
                                 $this->getContainer()->get('victoire_widget_map.builder')->build($replacedWidgetView);
-                                $replacedWidgetMap = $replacedWidgetView->getWidgetMapByWidget($replacedWidget);
+                                $replacedWidgetMap = WidgetMapHelper::getWidgetMapByWidgetAndView($replacedWidget, $replacedWidgetView);
                                 $widgetMap->setReplaced($replacedWidgetMap);
 
                                 $this->getContainer()->get('victoire_widget_map.manager')->moveChildren(

--- a/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
+++ b/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
@@ -199,6 +199,7 @@ class WidgetMapManager
         $widgetMap->setAction(WidgetMap::ACTION_OVERWRITE);
         $widgetMap->setReplaced($originalWidgetMap);
         $originalWidgetMap->addSubstitute($widgetMap);
+        $widgetMap->setView($view);
         $view->addWidgetMap($widgetMap);
         $this->em->persist($widgetMap);
 

--- a/Tests/Features/Widget/stilyze.feature
+++ b/Tests/Features/Widget/stilyze.feature
@@ -33,7 +33,7 @@ Feature: Stylize a widget
     Then I should see "Créer"
     When I fill in "Côté de la force" with "Obscure"
     And I submit the widget
-    Then I wait 1 second
+    Then I should see "Victoire !"
     Then I switch to "style" mode
     When I edit the "Force" widget
     Then I should see "Style du widget"


### PR DESCRIPTION
In the widgetmap migration command, when a widget need to be deleted in a child page we have do move it's children undder the parent of the deleted one.
The new generated overwrite widget didn't defind the view in witch it belongs so the parent view had an additional widgetmap that didn't belongs to.