### PR TITLE
extends Victoire:Layout:base.html.twig instead of "no more used" ::base.html.twig

### DIFF
--- a/Bundle/UserBundle/Resources/views/layout.html.twig
+++ b/Bundle/UserBundle/Resources/views/layout.html.twig
@@ -1,4 +1,4 @@
-{% extends '::base.html.twig' %}
+{% extends 'VictoireCoreBundle:Layout:base.html.twig' %}
 
 
 {% block head_style %}

--- a/Tests/Functionnal/app/Resources/views/base.html.twig
+++ b/Tests/Functionnal/app/Resources/views/base.html.twig
@@ -1,1 +1,0 @@
-{% extends 'VictoireCoreBundle:Layout:base.html.twig' %}


### PR DESCRIPTION
This PR allows project to use the default login template without ::base.html.twig