### PR TITLE
Feature/remove criteria operators select

### DIFF
--- a/Bundle/CriteriaBundle/Form/Type/CriteriaType.php
+++ b/Bundle/CriteriaBundle/Form/Type/CriteriaType.php
@@ -3,7 +3,6 @@
 namespace Victoire\Bundle\CriteriaBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -19,7 +18,7 @@ class CriteriaType extends AbstractType
             'label' => 'victoire_criteria.criteria.name.label',
         ]);
         $builder->add('operator', TextType::class, [
-            'vic_help_block' => 'victoire_criteria.criteria.operator.help_block',
+            'vic_help_block'    => 'victoire_criteria.criteria.operator.help_block',
             'label'             => 'victoire_criteria.criteria.operator.label',
         ]);
 

--- a/Bundle/CriteriaBundle/Form/Type/CriteriaType.php
+++ b/Bundle/CriteriaBundle/Form/Type/CriteriaType.php
@@ -5,6 +5,7 @@ namespace Victoire\Bundle\CriteriaBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -17,15 +18,8 @@ class CriteriaType extends AbstractType
         $builder->add('name', HiddenType::class, [
             'label' => 'victoire_criteria.criteria.name.label',
         ]);
-        $builder->add('operator', ChoiceType::class, [
-            'choices'           => [
-                'victoire_criteria.criteria.operator.equal.label'          => 'equal',
-                'victoire_criteria.criteria.operator.true.label'           => 'true',
-                'victoire_criteria.criteria.operator.false.label'          => 'false',
-                'victoire_criteria.criteria.operator.is_granted.label'     => 'is_granted',
-                'victoire_criteria.criteria.operator.is_not_granted.label' => 'is_not_granted',
-            ],
-            'choices_as_values' => true,
+        $builder->add('operator', TextType::class, [
+            'vic_help_block' => 'victoire_criteria.criteria.operator.help_block',
             'label'             => 'victoire_criteria.criteria.operator.label',
         ]);
 

--- a/Bundle/CriteriaBundle/Resources/translations/victoire.fr.xliff
+++ b/Bundle/CriteriaBundle/Resources/translations/victoire.fr.xliff
@@ -14,42 +14,27 @@
                 <source>victoire_criteria.request_scheme.criteria.label</source>
                 <target>SSL</target>
             </trans-unit>
-            <trans-unit id="3" resname="victoire_criteria.criteria.operator.equal.label">
-                <source>victoire_criteria.criteria.operator.equal.label</source>
-                <target>Égal</target>
-            </trans-unit>
-            <trans-unit id="4" resname="victoire_criteria.criteria.operator.is_granted.label">
-                <source>victoire_criteria.criteria.operator.is_granted.label</source>
-                <target>Possède le rôle</target>
-            </trans-unit>
-            <trans-unit id="5" resname="victoire_criteria.request_roles.criteria.label">
+            <trans-unit id="3" resname="victoire_criteria.request_roles.criteria.label">
                 <source>victoire_criteria.request_roles.criteria.label</source>
                 <target>Rôles</target>
             </trans-unit>
-            <trans-unit id="6" resname="victoire_criteria.request_user.is.connected.criteria.label">
+            <trans-unit id="4" resname="victoire_criteria.request_user.is.connected.criteria.label">
                 <source>victoire_criteria.request_user.is.connected.criteria.label</source>
                 <target>Connecté</target>
             </trans-unit>
-            <trans-unit id="7" resname="victoire_criteria.request_user.is.not.connected.criteria.label">
+            <trans-unit id="5" resname="victoire_criteria.request_user.is.not.connected.criteria.label">
                 <source>victoire_criteria.request_user.is.not.connected.criteria.label</source>
                 <target>Non connecté</target>
             </trans-unit>
-            <trans-unit id="8" resname="victoire_criteria.criteria.operator.true.label">
-                <source>victoire_criteria.criteria.operator.true.label</source>
-                <target>Vrai</target>
-            </trans-unit>
-            <trans-unit id="9" resname="victoire_criteria.request_user.criteria.label">
+            <trans-unit id="6" resname="victoire_criteria.request_user.criteria.label">
                 <source>victoire_criteria.request_user.criteria.label</source>
                 <target>Est connecté</target>
             </trans-unit>
-            <trans-unit id="10" resname="victoire_criteria.criteria.operator.false.label">
-                <source>victoire_criteria.criteria.operator.false.label</source>
-                <target>Faux</target>
-            </trans-unit>
-            <trans-unit id="11" resname="victoire_criteria.criteria.operator.is_not_granted.label">
-                <source>victoire_criteria.criteria.operator.is_not_granted.label</source>
-                <target>Ne possède pas le rôle</target>
+            <trans-unit id="7" resname="victoire_criteria.criteria.operator.help_block">
+                <source>victoire_criteria.criteria.operator.help_block</source>
+                <target>Valeurs prises en charge: equal, true, false, is_granted, is_not_granted</target>
             </trans-unit>
         </body>
     </file>
 </xliff>
+

--- a/Tests/Features/BusinessEntityPage/create.feature
+++ b/Tests/Features/BusinessEntityPage/create.feature
@@ -146,7 +146,7 @@ Feature: Create business entity pages
         And I select "side" from "jedi_a_businessEntity_widget_force[fields][side]"
         And should see "Critères"
         And I follow "Critères"
-        And I select "Possède le rôle" from "jedi_a_businessEntity_widget_force[criterias][2][operator]"
+        And I fill in "jedi_a_businessEntity_widget_force[criterias][2][operator]" with "is_granted"
         And I select "BUSINESS_ENTITY_OWNER" from "jedi_a_businessEntity_widget_force[criterias][2][value]"
         And I submit the widget
         Then I wait 2 seconds

--- a/UPGRADE-1.7.md
+++ b/UPGRADE-1.7.md
@@ -1,6 +1,6 @@
 #UPGRADE 1.7
 
-## v1.7.0
+## 1.7.0
 
 Layouts architecture were a piece of shit... this version cleans up but also breaks things and you need to follow these steps to fix your project:
 
@@ -20,4 +20,6 @@ Layouts architecture were a piece of shit... this version cleans up but also bre
     - wrap the `body_content_main` in a main#content tag
     - declare the **main_content** `cms_slot_widgets` (in the `body_content_main` block)
 - the `fos_js_routes.js` is now generated with the `prod` suffix in `prod` environment
+
+## 1.7.7
 - The "getMainCurrentView" method disapeard from CurrentViewHelper, you have to use "getCurrentView" instead, which have the exact same behavior.


### PR DESCRIPTION
The operator select was confusing because it was populated the same way for all criterias even if it has no sense (eq. "Locale" => "is_granted" => "fr")
Waiting for a more evoluted system, it is less confusing to ask the user to type manually the name of the operator.