### PR TITLE
:bug: prevent LinkExtension to add modalLayout when request is not xhr

### DIFF
--- a/Bundle/PageBundle/Controller/BasePageController.php
+++ b/Bundle/PageBundle/Controller/BasePageController.php
@@ -25,7 +25,7 @@ class BasePageController extends Controller
         $response = $this->get('victoire_page.page_helper')->renderPageByUrl(
             $url,
             $request->getLocale(),
-            $request->query->get('modalLayout', null)
+            $request->isXmlHttpRequest() ? $request->query->get('modalLayout', null) : null
         );
 
         //throw an exception is the page is not valid

--- a/Bundle/WidgetBundle/Twig/LinkExtension.php
+++ b/Bundle/WidgetBundle/Twig/LinkExtension.php
@@ -209,7 +209,7 @@ class LinkExtension extends \Twig_Extension
         }
 
         //Build the target attribute
-        if ($parameters['target'] == '_modal') {
+        if ($parameters['target'] == Link::TARGET_MODAL) {
             $attr['data-toggle'] = 'viclink-modal';
         } elseif ($parameters['target'] == '') {
             $attr['target'] = '_parent';
@@ -224,7 +224,7 @@ class LinkExtension extends \Twig_Extension
 
         $url = $this->victoireLinkUrl($parameters, true, $url);
         // if modalLayout is set, we add it as GET parameter
-        if (!empty($parameters['modalLayout'])) {
+        if ($parameters['target'] == Link::TARGET_MODAL && !empty($parameters['modalLayout'])) {
             $url .= !preg_match('/\?/', $url) ? '?' : '&';
             $url .= 'modalLayout='.$parameters['modalLayout'];
         }


### PR DESCRIPTION
## Type
Bugfix

## Purpose
The modalLayout is used even if request is not xhr

## BC Break
NO
