### PR TITLE
Use Template backendName if set in Template modal list

### DIFF
--- a/Bundle/TemplateBundle/Resources/views/Template/index.html.twig
+++ b/Bundle/TemplateBundle/Resources/views/Template/index.html.twig
@@ -12,7 +12,7 @@
 
 {% macro templatesHierarchy(templates) %}
     {% for template in templates %}
-      <li id="list_{{template.id}}"><a href="{{path('victoire_template_show', {'id' : template.id })}}">{{ template.name|default('#' ~ template.id) }}</a>
+      <li id="list_{{template.id}}"><a href="{{path('victoire_template_show', {'id' : template.id })}}">{{ template.backendName|default(template.name)|default('#' ~ template.id) }}</a>
       {% if template.templateInheritors %}
           <ul>
             {{ _self.templatesHierarchy(template.templateInheritors) }}


### PR DESCRIPTION
## Type
feature

## Purpose
This PR improve the template modal list reading by using template's backendName if set.

## BC Break
NO