### PR TITLE
BusinessEntity: Remove curly brackets in annotation

### DIFF
--- a/Bundle/BusinessEntityBundle/README.md
+++ b/Bundle/BusinessEntityBundle/README.md
@@ -53,7 +53,7 @@ namespace Acme\DemoBundle\Entity;
      * @var string
      *
      * @ORM\Column(name="title", type="string", length=255)
-     * @VIC\BusinessProperty({"textable"})
+     * @VIC\BusinessProperty("textable")
      */
     private $title;
     
@@ -61,7 +61,7 @@ namespace Acme\DemoBundle\Entity;
      * @var string
      *
      * @ORM\Column(name="description", type="string", length=255)
-     * @VIC\BusinessProperty({"textable"})
+     * @VIC\BusinessProperty("textable")
      */
     private $description;
 ```


### PR DESCRIPTION
## Type
Documentation

## Purpose
Doctrine annotations should not use curly brackets if only one item is present

## BC Break
NO