### PR TITLE
Allow insert current locale in getUrl

### DIFF
--- a/Bundle/PageBundle/Entity/Traits/WebViewTrait.php
+++ b/Bundle/PageBundle/Entity/Traits/WebViewTrait.php
@@ -170,9 +170,16 @@ trait WebViewTrait
         return $this;
     }
 
-    public function getUrl()
+    /**
+     * Get url.
+     *
+     * @param null $currentLocale
+     *
+     * @return mixed
+     */
+    public function getUrl($currentLocale = null)
     {
-        return PropertyAccess::createPropertyAccessor()->getValue($this->translate(null, false), 'getUrl');
+        return PropertyAccess::createPropertyAccessor()->getValue($this->translate($currentLocale, false), 'getUrl');
     }
 
     public function setUrl($name, $locale = null)


### PR DESCRIPTION
## Type
feature

## Purpose
This PR brings improvement of WebViewTrait for authorize to give currentLocale on getUrl.
In some case we search Url for a widget and we must give the locale of target view. 
ex. when we have a widgetFilter on a page who target a list on a different page, we must force locale otherwise getUrl returns defaultTranslation

## BC Break
NO

