### PR TITLE
do not join translations when building the BusinessPage or widget query

### DIFF
--- a/Bundle/QueryBundle/Helper/QueryHelper.php
+++ b/Bundle/QueryBundle/Helper/QueryHelper.php
@@ -64,7 +64,6 @@ class QueryHelper
             throw new \Exception('The container entity parameter must not be null.');
         }
 
-
         //the business name of the container entity
         $businessEntityId = $containerEntity->getBusinessEntityId();
 

--- a/Tests/Features/I18n/domainLocaleStragegy.feature
+++ b/Tests/Features/I18n/domainLocaleStragegy.feature
@@ -5,7 +5,6 @@ Feature: Domain strategy
     Given I maximize the window
     And I am on homepage
 
-  @smartStep
   Scenario: I check the domain strategy
     Given I visit homepage through domain "en.victoire.io"
     Then the title should be "Homepage"

--- a/Tests/Functionnal/src/Acme/AppBundle/Entity/SpaceShip.php
+++ b/Tests/Functionnal/src/Acme/AppBundle/Entity/SpaceShip.php
@@ -30,6 +30,15 @@ class SpaceShip
     private $id;
 
     /**
+     * @VIC\BusinessProperty("businessParameter")
+     */
+    private $slug;
+    /**
+     * @VIC\BusinessProperty("businessParameter")
+     */
+    private $name;
+
+    /**
      * @return int
      */
     public function getId()
@@ -49,7 +58,7 @@ class SpaceShip
 
     public function setName($name, $locale = null)
     {
-        $this->translate($locale, false)->setDescription($name);
+        $this->translate($locale, false)->setName($name);
         $this->mergeNewTranslations();
     }
 
@@ -60,7 +69,7 @@ class SpaceShip
 
     public function setSlug($slug, $locale = null)
     {
-        $this->translate($locale, false)->setDescription($slug);
+        $this->translate($locale, false)->setSlug($slug);
         $this->mergeNewTranslations();
     }
 }

--- a/Tests/Functionnal/src/Acme/AppBundle/Entity/SpaceShipTranslation.php
+++ b/Tests/Functionnal/src/Acme/AppBundle/Entity/SpaceShipTranslation.php
@@ -5,6 +5,7 @@ namespace Acme\AppBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Knp\DoctrineBehaviors\Model\Translatable\Translation;
+use Victoire\Bundle\CoreBundle\Annotations as VIC;
 
 /**
  * SpaceShipTranslation.
@@ -20,6 +21,7 @@ class SpaceShipTranslation
      * @var string
      *
      * @ORM\Column(name="name", type="string", length=55)
+     * @VIC\BusinessProperty("businessParameter")
      */
     protected $name;
 
@@ -30,6 +32,7 @@ class SpaceShipTranslation
      *     @Gedmo\SlugHandler(class="Victoire\Bundle\BusinessEntityBundle\Handler\TwigSlugHandler"
      * )},fields={"name"}, updatable=false, unique=false)
      * @ORM\Column(name="slug", type="string", length=255)
+     * @VIC\BusinessProperty("businessParameter")
      */
     protected $slug;
 


### PR DESCRIPTION
## Type
Bugfix

## Purpose

When checking if a Business Entity is allowed for a businessTemplate, a query is built. 
This query makes a join on translations, but in the case this query is build by a postPersist event, so the translations may be unknown by the entity manager resulting in a false positive for isEntityAllowed method.
The join seemed to be not necessary anymore so this PR removes it

## BC Break
NO
