### PR TITLE
media gallery image edit

### DIFF
--- a/Bundle/MediaBundle/Form/File/FileType.php
+++ b/Bundle/MediaBundle/Form/File/FileType.php
@@ -41,7 +41,7 @@ class FileType extends AbstractType
     }
 
     /**
-     * setup a custom name to avoid the automatic name theneration "file" that conflicts with "file" field name
+     * setup a custom name to avoid the automatic name theneration "file" that conflicts with "file" field name.
      */
     public function getBlockPrefix()
     {

--- a/Bundle/MediaBundle/Form/File/FileType.php
+++ b/Bundle/MediaBundle/Form/File/FileType.php
@@ -39,4 +39,12 @@ class FileType extends AbstractType
             'data_class' => 'Victoire\Bundle\MediaBundle\Helper\File\FileHelper',
         ]);
     }
+
+    /**
+     * setup a custom name to avoid the automatic name theneration "file" that conflicts with "file" field name
+     */
+    public function getBlockPrefix()
+    {
+        return 'media_file';
+    }
 }


### PR DESCRIPTION
## Type
Bugfix

## Purpose

The media gallery has an edit functionnality to change image name and file.
Since sf2.8, this feature leaded to a 500 error. 
There was conflict between the form name ("file") and the field name ("file" too) that leads to have all form data replaced by the fields data.
The error thrown was the following:
```
ncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Cannot use object of type Symfony\Component\HttpFoundation\File\UploadedFile as array" at /var/www/[...]/vendor/symfony/symfony/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php line 109
```

## BC Break
NO