### PR TITLE
make the current route match the sidebar route even with the locale r…

### DIFF
--- a/Bundle/MediaBundle/Helper/Menu/MediaMenuAdaptor.php
+++ b/Bundle/MediaBundle/Helper/Menu/MediaMenuAdaptor.php
@@ -81,7 +81,7 @@ class MediaMenuAdaptor implements MenuAdaptorInterface
                 $menuitem->setInternalname($folder->getName());
                 $menuitem->setParent($parent);
                 $menuitem->setRole($folder->getRel());
-                if (isset($currentFolder) && (stripos($request->attributes->get('_route'), $menuitem->getRoute()) === 0 || in_array($request->attributes->get('_route'), $allRoutes))) {
+                if (isset($currentFolder) && (stripos($request->attributes->get('_route'), $menuitem->getRoute()) !== false || in_array($request->attributes->get('_route'), $allRoutes))) {
                     if ($currentFolder->getId() == $folder->getId()) {
                         $menuitem->setActive(true);
                     } else {


### PR DESCRIPTION
…oute prefix (fr__my_route must match the route my_route)

## Type
Bugfix

## Purpose
The sidebar in media library disapeared when the I18n was activated because of strict route matching:
fr_my_route didn't match my_route.
Updated to a less strict check solved  this issue

## BC Break
NO
