### PR TITLE
use automatic form generation for media

### DIFF
--- a/Bundle/MediaBundle/Resources/views/Media/create.html.twig
+++ b/Bundle/MediaBundle/Resources/views/Media/create.html.twig
@@ -12,8 +12,6 @@
     {% form_theme form 'VictoireMediaBundle:Form:fields.html.twig' %}
 
     {{ form_start(form) }}
-        {{ form_row(form.name) }}
-        {{ form_widget(form.file) }}
         {{ form_rest(form) }}
         <div class="prop_wrp">
             <div class="input_prop">


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Video type has an "url" field while File type has a "file" field but both use the same twig template. Use automatic form rendering to be compliant with the two types

## BC Break
NO
