### PR TITLE
increase the size of the metaTitle to 65 char

### DIFF
--- a/Bundle/SeoBundle/Entity/PageSeo.php
+++ b/Bundle/SeoBundle/Entity/PageSeo.php
@@ -32,7 +32,7 @@ class PageSeo
      * @var string
      *
      * @ORM\Column(name="meta_title", type="string", nullable=true)
-     * @Assert\Length(max = 60)
+     * @Assert\Length(max = 65)
      */
     protected $metaTitle;
 

--- a/Bundle/SeoBundle/Entity/PageSeoTranslation.php
+++ b/Bundle/SeoBundle/Entity/PageSeoTranslation.php
@@ -22,7 +22,7 @@ class PageSeoTranslation
      * @var string
      *
      * @ORM\Column(name="meta_title", type="string", nullable=true)
-     * @Assert\Length(max = 60)
+     * @Assert\Length(max = 65)
      */
     protected $metaTitle;
 


### PR DESCRIPTION
## Type
Bugfix

## Purpose
increase the size of the metaTitle to 63 characters

## BC Break
NO
