### PR TITLE
[WIP] Composer: update doctrine/orm

### DIFF
--- a/Tests/Functionnal/app/AppKernel.php
+++ b/Tests/Functionnal/app/AppKernel.php
@@ -101,41 +101,10 @@ class AppKernel extends Kernel
      */
     public function shutdown()
     {
-        if ($this->environment === 'ci') {
-            if (false === $this->booted) {
-                return;
-            }
-
-            $container = $this->container;
-            parent::shutdown();
-            $this->cleanupContainer($container);
-        } else {
-            parent::shutdown();
+        if (($this->environment === 'ci') && (false === $this->booted)) {
+            return;
         }
-    }
 
-    /**
-     * Remove all container references from all loaded services.
-     */
-    protected function cleanupContainer($container)
-    {
-        $object = new \ReflectionObject($container);
-        $property = $object->getProperty('services');
-        $property->setAccessible(true);
-        $services = $property->getValue($container) ?: [];
-        foreach ($services as $id => $service) {
-            if ('kernel' === $id) {
-                continue;
-            }
-            $serviceObject = new \ReflectionObject($service);
-            foreach ($serviceObject->getProperties() as $prop) {
-                $prop->setAccessible(true);
-                if ($prop->isStatic()) {
-                    continue;
-                }
-                $prop->setValue($service, null);
-            }
-        }
-        $property->setValue($container, null);
+        parent::shutdown();
     }
 }

--- a/Tests/Functionnal/src/Acme/AppBundle/DataFixtures/Seeds/ORM/User/user.yml
+++ b/Tests/Functionnal/src/Acme/AppBundle/DataFixtures/Seeds/ORM/User/user.yml
@@ -7,8 +7,6 @@ Victoire\Bundle\UserBundle\Entity\User:
         lastname: Skywalker
         enabled: true
         locale: fr
-        locked: false
-        expired: false
         createdAt: <dateTime('now')>
         updatedAt: <dateTime('now')>
         roles:
@@ -22,7 +20,5 @@ Victoire\Bundle\UserBundle\Entity\User:
         lastname: 6PO
         enabled: true
         locale: fr
-        locked: false
-        expired: false
         createdAt: <dateTime('now')>
         updatedAt: <dateTime('now')>

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "doctrine/data-fixtures": "~1.1.1",
         "doctrine/doctrine-fixtures-bundle": "~2.2",
         "doctrine/doctrine-migrations-bundle": "^1.0",
-        "doctrine/orm": "v2.5.2",
+        "doctrine/orm": "~2.5.2@stable",
         "friendsofsymfony/jsrouting-bundle": "~2.0",
         "friendsofsymfony/user-bundle": "v2.0.0-beta1",
         "friendsofvictoire/text-widget": "~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ead07e88bcadad79fa1d0f5d211012f4",
-    "content-hash": "9b5a78abe9b4ce25c44764d7408d2fdb",
+    "content-hash": "03bdc21fc3807bcbca47d0299b8365d8",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -448,7 +447,7 @@
             "keywords": [
                 "database"
             ],
-            "time": "2015-03-30 12:14:13"
+            "time": "2015-03-30T12:14:13+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -688,7 +687,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-01-26 17:28:51"
+            "time": "2016-01-26T17:28:51+00:00"
         },
         {
             "name": "doctrine/doctrine-fixtures-bundle",
@@ -745,7 +744,7 @@
                 "Fixture",
                 "persistence"
             ],
-            "time": "2015-11-04 21:23:23"
+            "time": "2015-11-04T21:23:23+00:00"
         },
         {
             "name": "doctrine/doctrine-migrations-bundle",
@@ -1132,7 +1131,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2015-11-23 12:44:25"
+            "time": "2015-11-23T12:44:25+00:00"
         },
         {
             "name": "friendsofsymfony/jsrouting-bundle",
@@ -1195,19 +1194,20 @@
         },
         {
             "name": "friendsofsymfony/user-bundle",
-            "version": "dev-master",
+            "version": "v2.0.0-beta1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfSymfony/FOSUserBundle.git",
-                "reference": "a586a9333f81a1b87396303f0a4b2854f1a0648d"
+                "reference": "28151dcb25de663c05ce26917fd6a0b5cb2787cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSUserBundle/zipball/a586a9333f81a1b87396303f0a4b2854f1a0648d",
-                "reference": "a586a9333f81a1b87396303f0a4b2854f1a0648d",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSUserBundle/zipball/28151dcb25de663c05ce26917fd6a0b5cb2787cf",
+                "reference": "28151dcb25de663c05ce26917fd6a0b5cb2787cf",
                 "shasum": ""
             },
             "require": {
+                "paragonie/random_compat": "^1 || ^2",
                 "php": "^5.5.9 || ^7.0",
                 "symfony/form": "^2.7 || ^3.0",
                 "symfony/framework-bundle": "^2.7 || ^3.0",
@@ -1225,11 +1225,7 @@
                 "symfony/console": "^2.7 || ^3.0",
                 "symfony/phpunit-bridge": "^2.7 || ^3.0",
                 "symfony/validator": "^2.7 || ^3.0",
-                "symfony/yaml": "^2.7 || ^3.0",
-                "willdurand/propel-typehintable-behavior": "^1.0"
-            },
-            "suggest": {
-                "willdurand/propel-typehintable-behavior": "Needed when using the propel implementation"
+                "symfony/yaml": "^2.7 || ^3.0"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -1268,7 +1264,7 @@
             "keywords": [
                 "User management"
             ],
-            "time": "2016-10-24 14:16:11"
+            "time": "2016-11-29T14:53:27+00:00"
         },
         {
             "name": "friendsofvictoire/button-widget",
@@ -1314,7 +1310,7 @@
                 "victoire",
                 "widget"
             ],
-            "time": "2016-11-10 23:59:33"
+            "time": "2016-11-10T23:59:33+00:00"
         },
         {
             "name": "friendsofvictoire/text-widget",
@@ -1364,7 +1360,7 @@
                 "victoire",
                 "widget"
             ],
-            "time": "2016-08-22 12:56:40"
+            "time": "2016-08-22T12:56:40+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -1550,7 +1546,7 @@
                 "image manipulation",
                 "image processing"
             ],
-            "time": "2015-09-19 16:54:05"
+            "time": "2015-09-19T16:54:05+00:00"
         },
         {
             "name": "incenteev/composer-parameter-handler",
@@ -1805,7 +1801,7 @@
                 "annotations",
                 "aop"
             ],
-            "time": "2015-12-09 16:30:46"
+            "time": "2015-12-09T16:30:46+00:00"
         },
         {
             "name": "jms/cg",
@@ -1852,7 +1848,7 @@
             "keywords": [
                 "code generation"
             ],
-            "time": "2016-04-07 10:21:44"
+            "time": "2016-04-07T10:21:44+00:00"
         },
         {
             "name": "jms/di-extra-bundle",
@@ -2287,7 +2283,7 @@
                 "translatable",
                 "tree"
             ],
-            "time": "2016-09-30 06:03:12"
+            "time": "2016-09-30T06:03:12+00:00"
         },
         {
             "name": "knplabs/gaufrette",
@@ -2370,7 +2366,7 @@
                 "filesystem",
                 "media"
             ],
-            "time": "2014-02-24 18:17:33"
+            "time": "2014-02-24T18:17:33+00:00"
         },
         {
             "name": "knplabs/knp-menu",
@@ -2886,7 +2882,7 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2016-07-25 07:13:56"
+            "time": "2016-07-25T07:13:56+00:00"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -2998,7 +2994,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-10-17 15:23:22"
+            "time": "2016-10-17T15:23:22+00:00"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -3046,7 +3042,7 @@
                 "sequence",
                 "set"
             ],
-            "time": "2015-05-17 12:39:23"
+            "time": "2015-05-17T12:39:23+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -3096,7 +3092,7 @@
                 "php",
                 "type"
             ],
-            "time": "2015-07-25 16:39:46"
+            "time": "2015-07-25T16:39:46+00:00"
         },
         {
             "name": "predis/predis",
@@ -3651,7 +3647,7 @@
                 "compression",
                 "minification"
             ],
-            "time": "2015-12-28 13:12:39"
+            "time": "2015-12-28T13:12:39+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -4476,7 +4472,7 @@
                 "alert",
                 "bootstrap"
             ],
-            "time": "2016-10-24 16:19:13"
+            "time": "2016-10-24T16:19:13+00:00"
         },
         {
             "name": "troopers/assetic-injector-bundle",
@@ -4527,7 +4523,7 @@
                 "assetic",
                 "injector"
             ],
-            "time": "2016-10-03 14:16:23"
+            "time": "2016-10-03T14:16:23+00:00"
         },
         {
             "name": "twig/extensions",
@@ -4739,7 +4735,7 @@
                 }
             ],
             "description": "JSONP callback validator.",
-            "time": "2014-01-20 22:35:06"
+            "time": "2014-01-20T22:35:06+00:00"
         },
         {
             "name": "zendframework/zend-code",
@@ -5165,7 +5161,7 @@
                 "test",
                 "web"
             ],
-            "time": "2016-02-15 07:55:18"
+            "time": "2016-02-15T07:55:18+00:00"
         },
         {
             "name": "behat/mink-goutte-driver",
@@ -5598,7 +5594,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-05-18 16:56:05"
+            "time": "2016-05-18T16:56:05+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -5774,7 +5770,7 @@
                 }
             ],
             "description": "Some BEHAT contexts",
-            "time": "2016-08-05 08:12:05"
+            "time": "2016-08-05T08:12:05+00:00"
         },
         {
             "name": "lakion/mink-debug-extension",
@@ -5834,7 +5830,7 @@
                 "debug",
                 "logging"
             ],
-            "time": "2016-07-20 08:01:08"
+            "time": "2016-07-20T08:01:08+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -5933,7 +5929,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -5980,7 +5976,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-06-10T07:14:17+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -6105,7 +6101,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-09-14 06:51:16"
+            "time": "2015-09-14T06:51:16+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -6193,7 +6189,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -6237,7 +6233,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -6414,7 +6410,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-08-19 09:14:08"
+            "time": "2015-08-19T09:14:08+00:00"
         },
         {
             "name": "psr/http-message",
@@ -6748,7 +6744,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -6836,7 +6832,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "03bdc21fc3807bcbca47d0299b8365d8",
+    "content-hash": "d2f7d3c19e6669189b8a8b6736b333ac",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -1058,22 +1058,22 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "v2.5.2",
+            "version": "v2.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/doctrine2.git",
-                "reference": "464b5fdbfbbeb4a65465ac173c4c5d90960f41ff"
+                "reference": "e6c434196c8ef058239aaa0724b4aadb0107940b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/464b5fdbfbbeb4a65465ac173c4c5d90960f41ff",
-                "reference": "464b5fdbfbbeb4a65465ac173c4c5d90960f41ff",
+                "url": "https://api.github.com/repos/doctrine/doctrine2/zipball/e6c434196c8ef058239aaa0724b4aadb0107940b",
+                "reference": "e6c434196c8ef058239aaa0724b4aadb0107940b",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "~1.4",
                 "doctrine/collections": "~1.2",
-                "doctrine/common": ">=2.5-dev,<2.6-dev",
+                "doctrine/common": ">=2.5-dev,<2.8-dev",
                 "doctrine/dbal": ">=2.5-dev,<2.6-dev",
                 "doctrine/instantiator": "~1.0.1",
                 "ext-pdo": "*",
@@ -1082,7 +1082,6 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "dev-master",
                 "symfony/yaml": "~2.3|~3.0"
             },
             "suggest": {
@@ -1131,7 +1130,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2015-11-23T12:44:25+00:00"
+            "time": "2016-12-18T15:42:34+00:00"
         },
         {
             "name": "friendsofsymfony/jsrouting-bundle",
@@ -6888,6 +6887,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "doctrine/orm": 0,
         "infinite-networks/form-bundle": 20,
         "sensio/distribution-bundle": 20,
         "snc/redis-bundle": 20


### PR DESCRIPTION
## Type
Feature

## Purpose
This PR update the `composer.json` and `composer.lock` in order to update `doctrine/orm`.

I added the `@stable` flag to the version ORM so that it won't install a `dev` version (this is due to the fact that we have `"minimum-stability": "dev",` in `composer.json`).

:warning: It is based on a change from #779 (without this Composer had a conflict), so it should be merged after #779.

## BC Break
NO