### PR TITLE
:bug: :memo: use default locale in errorPage if the given one is not …

### DIFF
--- a/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -77,7 +77,7 @@ class ExceptionController extends BaseExceptionController
 
         $locale = $request->getLocale();
         if (!in_array($locale, $this->availableLocales, true)) {
-            $locale = $this->defaultLocale;
+            $request->setLocale($this->defaultLocale);
         }
         //if in production environment and the query is not a file
         if ($this->debug === false && 0 === $matches) {
@@ -85,7 +85,6 @@ class ExceptionController extends BaseExceptionController
             if ($page) {
                 return $this->forward('VictoireTwigBundle:ErrorPage:show', [
                         'code'    => $page->getCode(),
-                        '_locale' => $locale,
                 ]);
             }
         }

--- a/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -2,25 +2,55 @@
 
 namespace Victoire\Bundle\TwigBundle\Controller;
 
+use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\TwigBundle\Controller\ExceptionController as BaseExceptionController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\FlattenException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Component\Routing\Router;
 
+/**
+ * Redirects to a victoire error page when facing a Flatted Exception.
+ */
 class ExceptionController extends BaseExceptionController
 {
     private $em;
 
-    public function __construct(\Twig_Environment $twig, $debug, $em, $httpKernel, $requestStack, $router)
+    /**
+     * @var array Available locales for the Victoire website
+     */
+    private $availableLocales;
+    /**
+     * @var string the fallback locale
+     */
+    private $defaultLocale;
+
+    /**
+     * ExceptionController constructor.
+     *
+     * @param \Twig_Environment   $twig
+     * @param bool                $debug
+     * @param EntityManager       $em
+     * @param HttpKernelInterface $httpKernel
+     * @param RequestStack        $requestStack
+     * @param Router              $router
+     * @param array               $availableLocales
+     * @param string              $defaultLocale
+     */
+    public function __construct(\Twig_Environment $twig, $debug, EntityManager $em, HttpKernelInterface $httpKernel, RequestStack $requestStack, Router $router, array $availableLocales, $defaultLocale)
     {
+        parent::__construct($twig, $debug);
         $this->twig = $twig;
         $this->debug = $debug;
         $this->em = $em;
         $this->kernel = $httpKernel;
         $this->request = $requestStack->getCurrentRequest();
         $this->router = $router;
+        $this->availableLocales = $availableLocales;
+        $this->defaultLocale = $defaultLocale;
     }
 
     /**
@@ -45,14 +75,18 @@ class ExceptionController extends BaseExceptionController
 
         $matches = preg_match('/^.*(\..*)$/', array_pop($uriArray), $matches);
 
+        $locale = $request->getLocale();
+        if (!in_array($locale, $this->availableLocales, true)) {
+            $locale = $this->defaultLocale;
+        }
         //if in production environment and the query is not a file
         if ($this->debug === false && 0 === $matches) {
             $page = $this->em->getRepository('VictoireTwigBundle:ErrorPage')->findOneByCode($code);
             if ($page) {
                 return $this->forward('VictoireTwigBundle:ErrorPage:show', [
-                        'code' => $page->getCode(),
-                    ]
-                );
+                        'code'    => $page->getCode(),
+                        '_locale' => $locale,
+                ]);
             }
         }
 

--- a/Bundle/TwigBundle/Resources/config/services.xml
+++ b/Bundle/TwigBundle/Resources/config/services.xml
@@ -17,6 +17,8 @@
             <argument type="service" id="http_kernel"></argument>
             <argument type="service" id="request_stack"></argument>
             <argument type="service" id="router"></argument>
+            <argument>%victoire_i18n.available_locales%</argument>
+            <argument>%victoire_i18n.victoire_locale%</argument>
         </service>
         <service id="victoire_twig.kernelrequest.listener" class="%victoire_twig.kernel_request_listener.class%">
             <argument type="service" id="twig" />

--- a/Tests/Features/Page/error.feature
+++ b/Tests/Features/Page/error.feature
@@ -7,13 +7,13 @@ Background:
 
   Scenario: I cannot acces a non exitant page
     And I am on "/fr/imaginary-page"
-    Then I should see "404 not found"
+    Then the title should be "Page introuvable"
   Scenario: I cannot acces a page for a non exitant locale
     And I am on "/notalocale/"
-    Then I should see "404 not found"
+    Then the title should be "Page introuvable"
   Scenario: I cannot acces a non existant page for a non exitant locale
     And I am on "/notalocale/imaginary-page"
-    Then I should see "404 not found"
+    Then the title should be "Page introuvable"
   Scenario: I cannot acces a page for a inconsistant locale
     And I am on "/notalocale:/"
-    Then I should see "404 not found"
+    Then the title should be "Page introuvable"

--- a/Tests/Features/Page/error.feature
+++ b/Tests/Features/Page/error.feature
@@ -1,0 +1,19 @@
+@mink:selenium2 @alice(Page) @alice(ErrorPage) @reset-schema
+Feature: Page not found
+
+Background:
+    Given I maximize the window
+    And I am on homepage
+
+  Scenario: I cannot acces a non exitant page
+    And I am on "/fr/imaginary-page"
+    Then I should see "404 not found"
+  Scenario: I cannot acces a page for a non exitant locale
+    And I am on "/notalocale/"
+    Then I should see "404 not found"
+  Scenario: I cannot acces a non existant page for a non exitant locale
+    And I am on "/notalocale/imaginary-page"
+    Then I should see "404 not found"
+  Scenario: I cannot acces a page for a inconsistant locale
+    And I am on "/notalocale:/"
+    Then I should see "404 not found"


### PR DESCRIPTION
…known

## Type
Bugfix

## Purpose
When accessing a page with a bad locale as parameter, the ErrorController forwarded to the victoire ErrorPage with the bad locale, throwing an Exception that was handled by the ErrorPageController, leading to a cyclic error.
With this PR, when the locale is unknown by victoire, it is replaced by the default locale

Fixes #xxx

## BC Break
NO
