### PR TITLE
:wrench: Move "doctrine/doctrine-fixtures-bundle" in "require-dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
     "require": {
         "php": ">=5.5.9",
         "a2lix/translation-form-bundle": "^2.1",
-        "doctrine/doctrine-fixtures-bundle": "^2.2",
         "doctrine/doctrine-migrations-bundle": "^1.2",
         "doctrine/orm": "^2.5",
         "friendsofsymfony/jsrouting-bundle": "^1.0|^2.0",
@@ -74,7 +73,8 @@
         "phpunit/phpunit-mock-objects": "2.3.7",
         "phpunit/phpunit": "4.6.*",
         "sensio/generator-bundle": "~2.3",
-        "symfony/var-dumper": "~2.8|~3.1"
+        "symfony/var-dumper": "~2.8|~3.1",
+        "doctrine/doctrine-fixtures-bundle": "^2.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Type
Feature

## Purpose
Fixes #778

When a website is deployed on a production environment, the [`--no-dev` option of Composer](https://getcomposer.org/doc/03-cli.md#install) can be used to skip installation of `require-dev` dependencies. Since fixtures are not necessary on a production environment, `doctrine/doctrine-fixtures-bundle` can be skipped in this context.

## BC Break
NO
