### PR TITLE
New Command and Logs to find Widgetmap conflicts

### DIFF
--- a/Bundle/WidgetMapBundle/Builder/WidgetMapBuilder.php
+++ b/Bundle/WidgetMapBundle/Builder/WidgetMapBuilder.php
@@ -4,6 +4,7 @@ namespace Victoire\Bundle\WidgetMapBundle\Builder;
 
 use Victoire\Bundle\CoreBundle\Entity\View;
 use Victoire\Bundle\WidgetMapBundle\Entity\WidgetMap;
+use Victoire\Bundle\WidgetMapBundle\Resolver\WidgetMapChildrenResolver;
 use Victoire\Bundle\WidgetMapBundle\Warmer\ContextualViewWarmer;
 
 /**
@@ -14,15 +15,21 @@ use Victoire\Bundle\WidgetMapBundle\Warmer\ContextualViewWarmer;
 class WidgetMapBuilder
 {
     private $contextualViewWarmer;
+    private $resolver;
 
     /**
      * WidgetMapBuilder constructor.
      *
      * @param ContextualViewWarmer $contextualViewWarmer
+     * @param WidgetMapChildrenResolver $resolver
      */
-    public function __construct(ContextualViewWarmer $contextualViewWarmer)
+    public function __construct(
+        ContextualViewWarmer $contextualViewWarmer,
+        WidgetMapChildrenResolver $resolver
+    )
     {
         $this->contextualViewWarmer = $contextualViewWarmer;
+        $this->resolver = $resolver;
     }
 
     /**
@@ -113,7 +120,7 @@ class WidgetMapBuilder
      */
     protected function orderizeWidgetMap(WidgetMap $currentWidgetMap, $builtWidgetMap, $slot, $slotWidgetMaps, View $view)
     {
-        $children = $currentWidgetMap->getChildren($view);
+        $children = $this->resolver->getChildren($currentWidgetMap, $view);
         foreach ($children as $child) {
             // check if the founded child belongs to the view
             if (in_array($child, $slotWidgetMaps, true)) {

--- a/Bundle/WidgetMapBundle/Builder/WidgetMapBuilder.php
+++ b/Bundle/WidgetMapBundle/Builder/WidgetMapBuilder.php
@@ -20,14 +20,13 @@ class WidgetMapBuilder
     /**
      * WidgetMapBuilder constructor.
      *
-     * @param ContextualViewWarmer $contextualViewWarmer
+     * @param ContextualViewWarmer      $contextualViewWarmer
      * @param WidgetMapChildrenResolver $resolver
      */
     public function __construct(
         ContextualViewWarmer $contextualViewWarmer,
         WidgetMapChildrenResolver $resolver
-    )
-    {
+    ) {
         $this->contextualViewWarmer = $contextualViewWarmer;
         $this->resolver = $resolver;
     }

--- a/Bundle/WidgetMapBundle/Command/WidgetMapOverwriteValidationCommand.php
+++ b/Bundle/WidgetMapBundle/Command/WidgetMapOverwriteValidationCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Victoire\Bundle\WidgetMapBundle\Command;
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Victoire\Bundle\CoreBundle\Entity\View;
+use Victoire\Bundle\WidgetMapBundle\Entity\WidgetMap;
+
+class WidgetMapOverwriteValidationCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('victoire:widget-map:validate-overwrite')
+            ->setDescription('Check for each View if there is conflicts between WidgetMaps.');
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @throws \Exception
+     *
+     * @return bool
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $table = new Table($output);
+        $table->setHeaders([
+            'Contextual View',
+            'WidgetMaps in conflict',
+            'Parent WidgetMap',
+            'Slot',
+            'Position',
+        ]);
+
+        /** @var EntityManager $entityManager */
+        $entityManager = $this->getContainer()->get('doctrine.orm.entity_manager');
+        $contextualViewWarmer = $this->getContainer()->get('victoire_widget_map.contextual_view_warmer');
+
+        $conflictNb = 0;
+
+        $views = $entityManager->getRepository('Victoire\Bundle\CoreBundle\Entity\View')->findAll();
+        foreach ($views as $view) {
+
+            $widgetMaps = $contextualViewWarmer->warm($view);
+
+            foreach ($widgetMaps as $widgetMap) {
+
+                $positions = [WidgetMap::POSITION_BEFORE, WidgetMap::POSITION_AFTER];
+                $children = [];
+                foreach ($positions as $position) {
+
+                    $children[$position] = null;
+                    $matchingChildren = [];
+
+                    foreach ($widgetMap->getContextualChildren($position) as $_child) {
+                        if (null === $_child->getSubstituteForView($view)) {
+                            $children[$position] = $_child;
+                            $matchingChildren[] = $_child->getId();
+                            $parent = $_child->getParent()->getId();
+                            $slot = $_child->getSlot();
+                        }
+                    }
+
+                    if (!$children[$position] && $widgetMap->getReplaced()) {
+                        foreach ($widgetMap->getReplaced()->getContextualChildren($position) as $_child) {
+                            if (null === $_child->getSubstituteForView($view)) {
+                                $matchingChildren[] = $_child->getId();
+                                $parent = $_child->getParent()->getId();
+                                $slot = $_child->getSlot();
+                            }
+                        }
+                    }
+
+                    if (count($matchingChildren) > 1) {
+                        $conflictNb++;
+                        $table->addRow([
+                            $view->getId(),
+                            implode(', ', $matchingChildren),
+                            $parent,
+                            $slot,
+                            $position,
+                        ]);
+                    }
+                }
+            }
+        }
+
+        if($conflictNb > 0) {
+            $output->writeln(sprintf('<error>%s WidgetMaps conflicts found.</error>', $conflictNb));
+            $output->writeln('<error>At least one of those WidgetMaps must have a replace_id with action "overwrite".</error>');
+            $table->render();
+        } else {
+            $output->writeln('<info>No conflict found.</info>');
+        }
+    }
+}

--- a/Bundle/WidgetMapBundle/Command/WidgetMapOverwriteValidationCommand.php
+++ b/Bundle/WidgetMapBundle/Command/WidgetMapOverwriteValidationCommand.php
@@ -6,7 +6,6 @@ use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Victoire\Bundle\CoreBundle\Entity\View;
 use Victoire\Bundle\WidgetMapBundle\Entity\WidgetMap;
@@ -52,15 +51,12 @@ class WidgetMapOverwriteValidationCommand extends ContainerAwareCommand
 
         $views = $entityManager->getRepository('Victoire\Bundle\CoreBundle\Entity\View')->findAll();
         foreach ($views as $view) {
-
             $widgetMaps = $contextualViewWarmer->warm($view);
 
             foreach ($widgetMaps as $widgetMap) {
-
                 $positions = [WidgetMap::POSITION_BEFORE, WidgetMap::POSITION_AFTER];
                 $children = [];
                 foreach ($positions as $position) {
-
                     $children[$position] = null;
                     $matchingChildren = [];
 
@@ -97,7 +93,7 @@ class WidgetMapOverwriteValidationCommand extends ContainerAwareCommand
             }
         }
 
-        if($conflictNb > 0) {
+        if ($conflictNb > 0) {
             $output->writeln(sprintf('<error>%s WidgetMaps conflicts found.</error>', $conflictNb));
             $output->writeln('<error>At least one of those WidgetMaps must have a replace_id with action "overwrite".</error>');
             $table->render();

--- a/Bundle/WidgetMapBundle/Entity/WidgetMap.php
+++ b/Bundle/WidgetMapBundle/Entity/WidgetMap.php
@@ -423,14 +423,12 @@ class WidgetMap
                 return $substitute;
             }
 
-            while($template = $view->getTemplate()) {
+            while ($template = $view->getTemplate()) {
                 if ($substitute->getView() === $template) {
                     return $substitute;
                 }
             }
         }
-
-        return null;
     }
 
     /**

--- a/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
+++ b/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
@@ -19,16 +19,15 @@ class WidgetMapManager
     /**
      * WidgetMapManager constructor.
      *
-     * @param EntityManager $em
-     * @param WidgetMapBuilder $builder
+     * @param EntityManager             $em
+     * @param WidgetMapBuilder          $builder
      * @param WidgetMapChildrenResolver $resolver
      */
     public function __construct(
         EntityManager $em,
         WidgetMapBuilder $builder,
         WidgetMapChildrenResolver $resolver
-    )
-    {
+    ) {
         $this->em = $em;
         $this->builder = $builder;
         $this->resolver = $resolver;

--- a/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
+++ b/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
@@ -8,16 +8,30 @@ use Victoire\Bundle\WidgetBundle\Entity\Widget;
 use Victoire\Bundle\WidgetMapBundle\Builder\WidgetMapBuilder;
 use Victoire\Bundle\WidgetMapBundle\Entity\WidgetMap;
 use Victoire\Bundle\WidgetMapBundle\Helper\WidgetMapHelper;
+use Victoire\Bundle\WidgetMapBundle\Resolver\WidgetMapChildrenResolver;
 
 class WidgetMapManager
 {
     private $em;
     private $builder;
+    private $resolver;
 
-    public function __construct(EntityManager $em, WidgetMapBuilder $builder)
+    /**
+     * WidgetMapManager constructor.
+     *
+     * @param EntityManager $em
+     * @param WidgetMapBuilder $builder
+     * @param WidgetMapChildrenResolver $resolver
+     */
+    public function __construct(
+        EntityManager $em,
+        WidgetMapBuilder $builder,
+        WidgetMapChildrenResolver $resolver
+    )
     {
         $this->em = $em;
         $this->builder = $builder;
+        $this->resolver = $resolver;
     }
 
     /**
@@ -76,7 +90,7 @@ class WidgetMapManager
         $originalParent = $widgetMap->getParent();
         $originalPosition = $widgetMap->getPosition();
 
-        $children = $widgetMap->getChildren($view);
+        $children = $this->resolver->getChildren($widgetMap, $view);
         $beforeChild = !empty($children[WidgetMap::POSITION_BEFORE]) ? $children[WidgetMap::POSITION_BEFORE] : null;
         $afterChild = !empty($children[WidgetMap::POSITION_AFTER]) ? $children[WidgetMap::POSITION_AFTER] : null;
 
@@ -118,7 +132,7 @@ class WidgetMapManager
         $originalParent = $widgetMap->getParent();
         $originalPosition = $widgetMap->getPosition();
 
-        $children = $widgetMap->getChildren($view);
+        $children = $this->resolver->getChildren($widgetMap, $view);
         $beforeChild = !empty($children[WidgetMap::POSITION_BEFORE]) ? $children[WidgetMap::POSITION_BEFORE] : null;
         $afterChild = !empty($children[WidgetMap::POSITION_AFTER]) ? $children[WidgetMap::POSITION_AFTER] : null;
 
@@ -273,8 +287,8 @@ class WidgetMapManager
      */
     protected function getChildrenByView(WidgetMap $widgetMap)
     {
-        $beforeChilds = $widgetMap->getChilds(WidgetMap::POSITION_BEFORE);
-        $afterChilds = $widgetMap->getChilds(WidgetMap::POSITION_AFTER);
+        $beforeChilds = $widgetMap->getContextualChildren(WidgetMap::POSITION_BEFORE);
+        $afterChilds = $widgetMap->getContextualChildren(WidgetMap::POSITION_AFTER);
 
         $childrenByView['views'] = [];
         $childrenByView['before'] = [];

--- a/Bundle/WidgetMapBundle/Resolver/WidgetMapChildrenResolver.php
+++ b/Bundle/WidgetMapBundle/Resolver/WidgetMapChildrenResolver.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Victoire\Bundle\WidgetMapBundle\Resolver;
+
+use Symfony\Bridge\Monolog\Logger;
+use Victoire\Bundle\CoreBundle\Entity\View;
+use Victoire\Bundle\WidgetMapBundle\Entity\WidgetMap;
+
+class WidgetMapChildrenResolver
+{
+
+    private $logger;
+
+    /**
+     * WidgetMapChildrenResolver constructor.
+     * 
+     * @param Logger $logger
+     */
+    public function __construct(Logger $logger)
+    {
+        $this->logger = $logger;
+    }
+    
+    /**
+     * Return "after" and "before" children,
+     * based on contextual View and its Templates.
+     *
+     * @return array
+     */
+    public function getChildren(WidgetMap $widgetMap, View $view = null)
+    {
+        $positions = [WidgetMap::POSITION_BEFORE, WidgetMap::POSITION_AFTER];
+        $children = [];
+        foreach ($positions as $position) {
+
+            $matchingChildren = [];
+
+            //Position is null by default
+            $children[$position] = null;
+
+            //Pass through all current WidgetMap children for a given position
+            foreach ($widgetMap->getContextualChildren($position) as $_child) {
+                //If child don't have a substitute for this View and Templates, this is the one
+                if (null === $_child->getSubstituteForView($view)) {
+                    $children[$position] = $_child;
+                    $matchingChildren[] = $_child->getId();
+                }
+            }
+
+            //If children has not been found for this position
+            //and current WidgetMap is a substitute
+            if (!$children[$position] && $widgetMap->getReplaced()) {
+                //Pass through all replaced WidgetMap children for a given position
+                foreach ($widgetMap->getReplaced()->getContextualChildren($position) as $_child) {
+                    //If child don't have a substitute for this View and Templates, this is the one
+                    if (null === $_child->getSubstituteForView($view)) {
+                        $children[$position] = $_child;
+                        $matchingChildren[] = $_child->getId();
+                    }
+                }
+            }
+
+            $matchingChildren = array_unique($matchingChildren);
+            if (count($matchingChildren) > 1) {
+                $this->logger->critical(sprintf(
+                    'Conflict found between WidgetMaps %s for View %s',
+                    implode(', ', $matchingChildren),
+                    $view->getId()
+                ));
+            }
+
+        }
+
+        return $children;
+    }
+
+    /**
+     * @param $position
+     * @param View|null $view
+     *
+     * @return bool
+     */
+    public function hasChildren(WidgetMap $widgetMap, $position, View $view = null)
+    {
+        foreach ($this->getChildren($widgetMap, $view) as $child) {
+            if ($child && $child->getPosition() === $position) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Bundle/WidgetMapBundle/Resolver/WidgetMapChildrenResolver.php
+++ b/Bundle/WidgetMapBundle/Resolver/WidgetMapChildrenResolver.php
@@ -8,19 +8,18 @@ use Victoire\Bundle\WidgetMapBundle\Entity\WidgetMap;
 
 class WidgetMapChildrenResolver
 {
-
     private $logger;
 
     /**
      * WidgetMapChildrenResolver constructor.
-     * 
+     *
      * @param Logger $logger
      */
     public function __construct(Logger $logger)
     {
         $this->logger = $logger;
     }
-    
+
     /**
      * Return "after" and "before" children,
      * based on contextual View and its Templates.
@@ -32,7 +31,6 @@ class WidgetMapChildrenResolver
         $positions = [WidgetMap::POSITION_BEFORE, WidgetMap::POSITION_AFTER];
         $children = [];
         foreach ($positions as $position) {
-
             $matchingChildren = [];
 
             //Position is null by default
@@ -68,7 +66,6 @@ class WidgetMapChildrenResolver
                     $view->getId()
                 ));
             }
-
         }
 
         return $children;

--- a/Bundle/WidgetMapBundle/Resources/config/services.yml
+++ b/Bundle/WidgetMapBundle/Resources/config/services.yml
@@ -3,6 +3,7 @@ services:
         class: Victoire\Bundle\WidgetMapBundle\Builder\WidgetMapBuilder
         arguments:
             - "@victoire_widget_map.contextual_view_warmer"
+            - "@victoire_widget_map.children_resolver"
 
     victoire_widget_map.widget_data_warmer:
         class: Victoire\Bundle\WidgetMapBundle\Warmer\WidgetDataWarmer
@@ -18,3 +19,9 @@ services:
         arguments:
             - "@doctrine.orm.entity_manager"
             - "@victoire_widget_map.builder"
+            - "@victoire_widget_map.children_resolver"
+
+    victoire_widget_map.children_resolver:
+        class: Victoire\Bundle\WidgetMapBundle\Resolver\WidgetMapChildrenResolver
+        arguments:
+            - "@logger"


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Fixes #806 
Add new Command to identify broken WidgetMaps
Isolate WidgetMap.getChildren method in an external service and log (CRITICAL) when WidgetMap are in conflict.

## BC Break
NO