### PR TITLE
Widget map deletion children issue

### DIFF
--- a/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
+++ b/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
@@ -97,8 +97,6 @@ class WidgetMapManager
 
         $widgetMap = $this->moveWidgetMap($view, $widgetMap, $parentWidgetMap, $position, $slot);
 
-        // If the moved widgetMap has someone at both his before and after, arbitrary move UP the before side
-        // and find the first place after the before widgetMap hierarchy to place the after widgetMap.
         $this->moveChildren($view, $beforeChild, $afterChild, $originalParent, $originalPosition);
 
         foreach ($parentWidgetMapChildren['views'] as $_view) {
@@ -162,7 +160,13 @@ class WidgetMapManager
             $view->addWidgetMap($replaceWidgetMap);
         }
 
+        //Move children for current WidgetMap View
         $this->moveChildren($view, $beforeChild, $afterChild, $originalParent, $originalPosition);
+
+        //Move children WidgetMap for children from other View
+        foreach ($widgetMap->getChildren() as $child) {
+            $this->moveWidgetMap($child->getView(), $child, $originalParent, $originalPosition);
+        }
     }
 
     /**

--- a/Tests/Features/WidgetMap/widgetMapTemplate.feature
+++ b/Tests/Features/WidgetMap/widgetMapTemplate.feature
@@ -369,8 +369,8 @@ Scenario: I delete an overwrite widget on template
     And I should not see "Widget 4"
     When I switch to "edit" mode
     And I press the "Widget 2" content
-    Then I should see "SUPPRIMER"
-    When I follow "SUPPRIMER"
+    Then I should see "Supprimer"
+    When I follow "Supprimer"
     Then I should see "Cette action va définitivement supprimer ce contenu. Cette action est irréversible."
     And I should see "Êtes-vous sûr ?"
     When I press "J'ai bien compris, je confirme la suppression"

--- a/Tests/Features/WidgetMap/widgetMapTemplate.feature
+++ b/Tests/Features/WidgetMap/widgetMapTemplate.feature
@@ -342,3 +342,45 @@ Scenario: I delete an overwrite widget on template
   Then I should see "Widget 1"
   Then I should see "Widget 2"
   Then I should see "Widget 3 overwrite"
+
+  @reset-schema
+  Scenario: I delete a widget from template which has children WidgetMap in inherited page
+    Given the following WidgetMaps:
+      | id | action | position | parent | slot         | view | replaced |
+      | 1  | create |          |        | main_content | base |          |
+      | 2  | create | after    | 1      | main_content | base |          |
+      | 3  | create | after    | 2      | main_content | home |          |
+      | 4  | create | after    | 3      | main_content | home |          |
+    Given the following WidgetTexts:
+      | content  | mode   | widgetMap |
+      | Widget 1 | static | 1         |
+      | Widget 2 | static | 2         |
+      | Widget 3 | static | 3         |
+      | Widget 4 | static | 4         |
+    When I am on the homepage
+    Then I should see "Widget 1"
+    And I should see "Widget 2"
+    And I should see "Widget 3"
+    And I should see "Widget 4"
+    And I am on "/fr/victoire-dcms/template/show/1"
+    Then I should see "Widget 1"
+    And I should see "Widget 2"
+    And I should not see "Widget 3"
+    And I should not see "Widget 4"
+    When I switch to "edit" mode
+    And I press the "Widget 2" content
+    Then I should see "SUPPRIMER"
+    When I follow "SUPPRIMER"
+    Then I should see "Cette action va définitivement supprimer ce contenu. Cette action est irréversible."
+    And I should see "Êtes-vous sûr ?"
+    When I press "J'ai bien compris, je confirme la suppression"
+    And I reload the page
+    Then I should see "Widget 1"
+    And I should not see "Widget 2"
+    And I should not see "Widget 3"
+    And I should not see "Widget 4"
+    When I am on the homepage
+    Then I should see "Widget 1"
+    And I should not see "Widget 2"
+    And I should see "Widget 3"
+    And I should see "Widget 4"


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Fix issue when a widget map is deleted in template and have children in inherited pages
Fixes #817

## BC Break
NO