### PR TITLE
use default locale in errorPage if the given one is not known

### DIFF
--- a/Tests/Features/Page/error.feature
+++ b/Tests/Features/Page/error.feature
@@ -5,7 +5,7 @@ Background:
     Given I maximize the window
     And I am on homepage
 
-  Scenario: I cannot acces a non exitant page
+  Scenario: I cannot acces a non-existant page
     And I am on "/fr/imaginary-page"
     Then the title should be "Page introuvable"
   Scenario: I cannot acces a page for a non exitant locale


### PR DESCRIPTION
## Type
Bugfix

## Purpose
When accessing a page with a bad locale as parameter, the ErrorController forwarded to the victoire ErrorPage with the bad locale, throwing an Exception that was handled by the ErrorPageController, leading to a cyclic error.
With this PR, when the locale is unknown by victoire, it is replaced by the default locale
 
## BC Break
NO
