### PR TITLE
Make Blog > Tag a BusinessEntity

### DIFF
--- a/Bundle/BlogBundle/Entity/Tag.php
+++ b/Bundle/BlogBundle/Entity/Tag.php
@@ -4,15 +4,20 @@ namespace Victoire\Bundle\BlogBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
+use Victoire\Bundle\BusinessEntityBundle\Entity\Traits\BusinessEntityTrait;
+use Victoire\Bundle\CoreBundle\Annotations as VIC;
 
 /**
  * Tag.
  *
  * @ORM\Table("vic_tag")
  * @ORM\Entity(repositoryClass="Victoire\Bundle\BlogBundle\Repository\TagRepository")
+ * @VIC\BusinessEntity("Listing")
  */
 class Tag
 {
+    use BusinessEntityTrait;
+
     /**
      * @var int
      *

--- a/Bundle/BlogBundle/Resources/translations/victoire.en.xliff
+++ b/Bundle/BlogBundle/Resources/translations/victoire.en.xliff
@@ -6,6 +6,10 @@
         <source>form.widget.tab.article.label</source>
         <target state="new">Post</target>
       </trans-unit>
+      <trans-unit id="58893b9921bc8" resname="form.widget.tab.tag.label">
+        <source>form.widget.tab.article.label</source>
+        <target>Tags</target>
+      </trans-unit>
       <trans-unit id="58893b9921c0b" resname="entity_proxy.form.article.label">
         <source>entity_proxy.form.article.label</source>
         <target>Post</target>

--- a/Bundle/BlogBundle/Resources/translations/victoire.es.xliff
+++ b/Bundle/BlogBundle/Resources/translations/victoire.es.xliff
@@ -6,6 +6,10 @@
         <source>form.widget.tab.article.label</source>
         <target state="new">Artículo</target>
       </trans-unit>
+      <trans-unit id="58893b9921bc9" resname="form.widget.tab.tag.label">
+        <source>form.widget.tab.article.label</source>
+        <target>Etiquetas</target>
+      </trans-unit>
       <trans-unit id="58893b9923171" resname="entity_proxy.form.article.label">
         <source>entity_proxy.form.article.label</source>
         <target>Artículo</target>

--- a/Bundle/BlogBundle/Resources/translations/victoire.fr.xliff
+++ b/Bundle/BlogBundle/Resources/translations/victoire.fr.xliff
@@ -6,6 +6,10 @@
         <source>form.widget.tab.article.label</source>
         <target state="new">Article</target>
       </trans-unit>
+      <trans-unit id="58893b9921bca" resname="form.widget.tab.tag.label">
+        <source>form.widget.tab.article.label</source>
+        <target>Etiquettes</target>
+      </trans-unit>
       <trans-unit id="58893b99249d5" resname="entity_proxy.form.article.label">
         <source>entity_proxy.form.article.label</source>
         <target>Article</target>


### PR DESCRIPTION
## Type
Feature

## Purpose
This PR fixes #841.

## BC Break
NO

---

This is useful to show tags on a blog article with the following query:

     JOIN item.articles article WHERE article = :currentEntity

The `listing-widget/Victoire/Widget/ListingBundle/Resources/views/_showItem.html.twig` file must be modified (for example by creating a theme) in order to display only the `title` of Tag:

    {{ item.title }}