### PR TITLE
avoid to add a widget already set in a widgetmap

### DIFF
--- a/Bundle/WidgetMapBundle/Entity/WidgetMap.php
+++ b/Bundle/WidgetMapBundle/Entity/WidgetMap.php
@@ -121,6 +121,7 @@ class WidgetMap
     {
         $this->children = new ArrayCollection();
         $this->substitutes = new ArrayCollection();
+        $this->widgets = new ArrayCollection();
     }
 
     /**
@@ -194,7 +195,9 @@ class WidgetMap
      */
     public function addWidget(Widget $widget)
     {
-        $this->widgets[] = $widget;
+        if (!$this->widgets->contains($widget)) {
+            $this->widgets->add($widget);
+        }
 
         return $this;
     }


### PR DESCRIPTION
## Type
Bugfix

## Purpose
With no check on addWidget method, it could occur that a WidgetMap has two times the same Widget

## BC Break
NO
