### PR TITLE
Removed gpc_magic_quotes ini setting

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -6,7 +6,6 @@
     * [ctype extension](http://php.net/manual/book.ctype.php) needs to be enabled
     * php.ini recommended settings
         * short_open_tag = Off
-        * magic_quotes_gpc = Off
         * register_globals = Off
         * session.auto_start = Off
         * date.timezone should be configured


### PR DESCRIPTION
gpc_magic_quotes setting was removed in v5.4 and is just ignored since then. 

No need to mention it, just confuses folks.

## Type
documentation

## Purpose
This PR improves documentation of dependencies

## BC Break
NO

