### PR TITLE
Use the model rather than the entity

### DIFF
--- a/Bundle/BlogBundle/Manager/ArticleManager.php
+++ b/Bundle/BlogBundle/Manager/ArticleManager.php
@@ -11,7 +11,7 @@ use Victoire\Bundle\BusinessPageBundle\Transformer\VirtualToBusinessPageTransfor
 use Victoire\Bundle\CoreBundle\Entity\View;
 use Victoire\Bundle\PageBundle\Entity\PageStatus;
 use Victoire\Bundle\PageBundle\Helper\PageHelper;
-use Victoire\Bundle\UserBundle\Entity\User;
+use Victoire\Bundle\UserBundle\Model\User;
 use Victoire\Bundle\ViewReferenceBundle\Connector\ViewReferenceRepository;
 use Victoire\Bundle\ViewReferenceBundle\Exception\ViewReferenceNotFoundException;
 


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Fix issue than prevents article creation in blog when project extend victoire user model rather than victoire user entity.
The entity extends the model so it should not break anything

## BC Break
NO
