### PR TITLE
Merge patchs from 2.2 into 2.3

### DIFF
--- a/Bundle/BlogBundle/Manager/ArticleManager.php
+++ b/Bundle/BlogBundle/Manager/ArticleManager.php
@@ -11,7 +11,7 @@ use Victoire\Bundle\BusinessPageBundle\Transformer\VirtualToBusinessPageTransfor
 use Victoire\Bundle\CoreBundle\Entity\View;
 use Victoire\Bundle\PageBundle\Entity\PageStatus;
 use Victoire\Bundle\PageBundle\Helper\PageHelper;
-use Victoire\Bundle\UserBundle\Entity\User;
+use Victoire\Bundle\UserBundle\Model\User;
 use Victoire\Bundle\ViewReferenceBundle\Connector\ViewReferenceRepository;
 use Victoire\Bundle\ViewReferenceBundle\Exception\ViewReferenceNotFoundException;
 

--- a/Bundle/CoreBundle/Resources/config/assetic_injector.json
+++ b/Bundle/CoreBundle/Resources/config/assetic_injector.json
@@ -13,7 +13,6 @@
             ],
             "victoire-ngApp":
             [
-                "https://code.angularjs.org/1.4.1/angular-sanitize.min.js",
                 "@VictoireCoreBundle/Resources/script/ngApp/app.js",
                 "@VictoireCoreBundle/Resources/script/ngApp/filters/translateFilter.js",
                 "@VictoireCoreBundle/Resources/script/ngApp/controllers/page/PageCtrl.js",

--- a/Bundle/CoreBundle/Resources/views/Layout/layout.html.twig
+++ b/Bundle/CoreBundle/Resources/views/Layout/layout.html.twig
@@ -140,6 +140,7 @@
             <script src="{{ path('fos_js_routing_js', {"callback": "fos.Router.setData"}) }}"></script>
         {% endif %}
 
+        <script type="text/javascript" src="https://code.angularjs.org/1.4.1/angular-sanitize.min.js"></script>
         {% javascripts injector="foot, victoire-ngApp, alertify-codrops-notification" %}
             <script type="text/javascript" src="{{ asset_url }}"></script>
         {% endjavascripts %}

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -10,13 +10,12 @@ default:
              paths:
                  - Tests/Features
              contexts:
-                 - Victoire\Tests\Features\Context\CoverageContext
+                 - Knp\FriendlyContexts\Context\EntityContext
+                 - Knp\FriendlyContexts\Context\AliceContext
+                 - Victoire\Tests\Features\Context\VictoireContext
                  - Victoire\Tests\Features\Context\FeatureContext
                  - Victoire\Tests\Features\Context\JavascriptContext
                  - Victoire\Tests\Features\Context\MinkContext
-                 - Victoire\Tests\Features\Context\VictoireContext
-                 - Knp\FriendlyContexts\Context\AliceContext
-                 - Knp\FriendlyContexts\Context\EntityContext
                  - Knp\FriendlyContexts\Context\TableContext
 
     extensions:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -13,6 +13,7 @@ default:
                  - Knp\FriendlyContexts\Context\EntityContext
                  - Knp\FriendlyContexts\Context\AliceContext
                  - Victoire\Tests\Features\Context\VictoireContext
+                 - Victoire\Tests\Features\Context\CoverageContext		
                  - Victoire\Tests\Features\Context\FeatureContext
                  - Victoire\Tests\Features\Context\JavascriptContext
                  - Victoire\Tests\Features\Context\MinkContext


### PR DESCRIPTION
## Type
Bugfix

## Purpose
- Reorder Contexts to reset schema, then load fixture, then generate viewReferences
- Removes from assetic_injector cdn assets
- Use User model rather than the entity

## BC Break
NO