### PR TITLE
Bugfix/widget locale

### DIFF
--- a/Bundle/WidgetBundle/Entity/Widget.php
+++ b/Bundle/WidgetBundle/Entity/Widget.php
@@ -548,20 +548,21 @@ class Widget extends BaseWidget implements VictoireQueryInterface
     }
 
     /**
+     * This method parse the widget criterias to discover in which locale this widget is used
      * @param $defaultLocale
      *
-     * @return mixed
+     * @return string|null
      */
-    public function getLocale($defaultLocale)
+    public function guessLocale()
     {
         if ($this->hasCriteriaNamed('locale')) {
             foreach ($this->getCriterias() as $criteria) {
-                if ($criteria->getName() === 'locale' && $criteria->getValue() === $defaultLocale) {
+                if ($criteria->getName() === 'locale') {
                     return $criteria->getValue();
                 }
             }
         }
 
-        return $defaultLocale;
+        return null;
     }
 }

--- a/Bundle/WidgetBundle/Entity/Widget.php
+++ b/Bundle/WidgetBundle/Entity/Widget.php
@@ -548,7 +548,8 @@ class Widget extends BaseWidget implements VictoireQueryInterface
     }
 
     /**
-     * This method parse the widget criterias to discover in which locale this widget is used
+     * This method parse the widget criterias to discover in which locale this widget is used.
+     *
      * @param $defaultLocale
      *
      * @return string|null
@@ -562,7 +563,5 @@ class Widget extends BaseWidget implements VictoireQueryInterface
                 }
             }
         }
-
-        return null;
     }
 }

--- a/Bundle/WidgetBundle/Resolver/BaseWidgetContentResolver.php
+++ b/Bundle/WidgetBundle/Resolver/BaseWidgetContentResolver.php
@@ -136,9 +136,12 @@ class BaseWidgetContentResolver
         //parse the field
         foreach ($fields as $widgetField => $field) {
             //get the value of the field
-            if ($entity !== null) {
-                $accessor = new PropertyAccessor();
-                $attributeValue = $accessor->getValue($entity, $field);
+            if (null !== $entity) {
+                $attributeValue = null;
+                if (null !== $field) {
+                    $accessor = new PropertyAccessor();
+                    $attributeValue = $accessor->getValue($entity, $field);
+                }
             } else {
                 $attributeValue = $widget->getBusinessEntityName().' -> '.$field;
             }

--- a/Bundle/WidgetBundle/Twig/LinkExtension.php
+++ b/Bundle/WidgetBundle/Twig/LinkExtension.php
@@ -46,7 +46,7 @@ class LinkExtension extends \Twig_Extension
      * @param EntityManager        $em
      * @param LoggerInterface      $logger
      * @param EntityRepository     $errorPageRepository
-     * @param                      $defaultLocale
+     * @param string               $defaultLocale
      * @param array                $abstractBusinessTemplates
      */
     public function __construct(
@@ -166,8 +166,9 @@ class LinkExtension extends \Twig_Extension
                 ) {
                     /** @var View $view */
                     $view = $attachedWidget->getWidgetMap()->getView();
-                    /* @var Widget $attachedWidget */
-                    $locale = $attachedWidget->getLocale($this->request ? $this->request->getLocale() : $this->defaultLocale);
+                    if (!$locale = $attachedWidget->guessLocale()) {
+                        $locale = $this->request ? $this->request->getLocale() : $this->defaultLocale;
+                    }
                     $view->translate($locale);
                     $url .= $this->router->generate('victoire_core_page_show', ['_locale' => $locale, 'url' => $view->getUrl()], $referenceType);
                 }


### PR DESCRIPTION
## Type
Bugfix

## Purpose
The getLocale() method had a too generic name and had no sense with the `$criteria->getValue() === $defaultLocale` condition, it always returned `$defaultLocale` value.

This method was introduced in #514 to generate a link to a good localized page when the link is configured to point to a widget (anchor strategy in LinkExtension). The widget has no locale itself so we have to parse the criteria to find a locale one.

## BC Break
NO
