### PR TITLE
fix twig deprecated

### DIFF
--- a/Bundle/BlogBundle/Resources/views/Blog/Tabs/_links.html.twig
+++ b/Bundle/BlogBundle/Resources/views/Blog/Tabs/_links.html.twig
@@ -1,20 +1,5 @@
 {% trans_default_domain "victoire" %}
 
-<div class="vic-tab-content vic-modal-tab-content">
-    <div class="vic-tab-pane vic-active" id="links">
-        <ul>
-            <li>
-                <a href="{{ path('victoire_core_page_show', {'url': blog.url}) }}">URL</a>
-            </li>
-            <li>
-                <a href="{{ path('victoire_blog_rss', {'id': blog.id}) }}">RSS</a>
-                {{ _self.blog_rss_category(blog, blog.categories) }}
-                </ul>
-            </li>
-        </ul>
-    </div>
-</div>
-
 {% macro blog_rss_category(blog, categories) %}
     {% if categories|length %}
         <ul>
@@ -28,3 +13,21 @@
         </ul>
     {% endif %}
 {% endmacro %}
+
+{% import _self as macro %}
+
+<div class="vic-tab-content vic-modal-tab-content">
+    <div class="vic-tab-pane vic-active" id="links">
+        <ul>
+            <li>
+                <a href="{{ path('victoire_core_page_show', {'url': blog.url}) }}">URL</a>
+            </li>
+            <li>
+                <a href="{{ path('victoire_blog_rss', {'id': blog.id}) }}">RSS</a>
+                {{ macro.blog_rss_category(blog, blog.categories) }}
+                </ul>
+            </li>
+        </ul>
+    </div>
+</div>
+


### PR DESCRIPTION
## Type
Bugfix

## Purpose
No PR opened, but when you install Victoire 2.3 on SF 3.2 you can't access to the blog section due to a deprecated syntax on twig.

