### PR TITLE
insert twig globals at bundle boot

### DIFF
--- a/Bundle/I18nBundle/DependencyInjection/VictoireI18nExtension.php
+++ b/Bundle/I18nBundle/DependencyInjection/VictoireI18nExtension.php
@@ -27,7 +27,6 @@ class VictoireI18nExtension extends Extension implements PrependExtensionInterfa
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
-
         $container->setParameter(
             'victoire_i18n.available_locales', $config['available_locales']
         );

--- a/Bundle/I18nBundle/DependencyInjection/VictoireI18nExtension.php
+++ b/Bundle/I18nBundle/DependencyInjection/VictoireI18nExtension.php
@@ -27,9 +27,14 @@ class VictoireI18nExtension extends Extension implements PrependExtensionInterfa
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
+
         $container->setParameter(
             'victoire_i18n.available_locales', $config['available_locales']
         );
+
+        $twigConfig['globals']['victoire_i18n_available_locales'] = $container->getParameter('victoire_i18n.available_locales');
+        $container->prependExtensionConfig('twig', $twigConfig);
+
         $container->setParameter(
             'victoire_i18n.locale_pattern_table', $config['locale_pattern_table']
         );

--- a/Bundle/TwigBundle/DependencyInjection/VictoireTwigExtension.php
+++ b/Bundle/TwigBundle/DependencyInjection/VictoireTwigExtension.php
@@ -28,5 +28,8 @@ class VictoireTwigExtension extends Extension
         $container->setParameter(
             'victoire_twig.responsive', $config['responsive']
         );
+
+        $twigConfig['globals']['victoire_twig_responsive'] = $container->getParameter('victoire_twig.responsive');
+        $container->prependExtensionConfig('twig', $twigConfig);
     }
 }


### PR DESCRIPTION
## Type
Bugfix

## Purpose
In twig ~2.0, globals can be modified but not declared after initialization, leading to exceptions like:
```
Unable to add global "victoire_i18n_available_locales" as the runtime or the extensions have already been initialized.
```
To solve this, I ask DependencyInjection to insert these globals at bundle initialization.

## BC Break
NO
