### PR TITLE
Fix bug with locale on blog articles list

### DIFF
--- a/Bundle/BlogBundle/Resources/views/Blog/Tabs/_articles.html.twig
+++ b/Bundle/BlogBundle/Resources/views/Blog/Tabs/_articles.html.twig
@@ -41,7 +41,7 @@
 
                     <time datetime="{{ article.publishedAt|date("Y-m-d") }}" class="vic-panelBlog-date">{{ article.publishedAt|localizeddate("medium", "none", null, null, "cccc d LLLL yyyy") }}</time>
 
-                    <a class="vic-btn vic-btn-sm vic-btn-default" href="{{ path('victoire_blog_article_settings', {'id' : article.id}) }}" data-toggle="vic-modal">{{'modal.blog.list.articlesList.change.parameters'|trans({}, 'victoire')}}</a>
+                    <a class="vic-btn vic-btn-sm vic-btn-default" href="{{ path('victoire_blog_article_settings', {'id' : article.id, '_locale': locale}) }}" data-toggle="vic-modal">{{'modal.blog.list.articlesList.change.parameters'|trans({}, 'victoire')}}</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Type
Feature

## Purpose
This PR brings support of automatic change of locale when editing blog articles.

When editing an article in another language that the current language, the default tab was not open. This PR fixes this problem.

See #904 and #906.

## BC Break
NO

Thanks to @Charlie-Lucas!