### PR TITLE
Order to define the victoire bundles in AppKernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /Tests/App/app/config/parameters.yml
 /Bundle/UIBundle/Resources/public/bower_components/*
 node_modules
+/.idea

--- a/Tests/App/app/AppKernel.php
+++ b/Tests/App/app/AppKernel.php
@@ -61,12 +61,14 @@ class AppKernel extends Kernel
                 new Victoire\Bundle\ViewReferenceBundle\ViewReferenceBundle(),
                 new Victoire\Bundle\WidgetBundle\VictoireWidgetBundle(),
                 new Victoire\Bundle\WidgetMapBundle\VictoireWidgetMapBundle(),
-                new Victoire\Bundle\BlogBundle\VictoireBlogBundle(),
 
                 //Victoire minimal test bundles
                 new Victoire\Widget\ForceBundle\VictoireWidgetForceBundle(),
                 new Victoire\Widget\LightSaberBundle\VictoireWidgetLightSaberBundle(),
                 new Victoire\Widget\TextBundle\VictoireWidgetTextBundle(),
+
+                new Victoire\Bundle\BlogBundle\VictoireBlogBundle(),
+
                 new Acme\AppBundle\AcmeAppBundle(),
             ],
             $this->getTestBundles()

--- a/Tests/App/app/AppKernel.php
+++ b/Tests/App/app/AppKernel.php
@@ -44,7 +44,6 @@ class AppKernel extends Kernel
                 new Victoire\Bundle\AnalyticsBundle\VictoireAnalyticsBundle(),
                 new Victoire\Bundle\CoreBundle\VictoireCoreBundle(),
                 new Victoire\Bundle\CriteriaBundle\VictoireCriteriaBundle(),
-                new Victoire\Bundle\BlogBundle\VictoireBlogBundle(),
                 new Victoire\Bundle\BusinessEntityBundle\VictoireBusinessEntityBundle(),
                 new Victoire\Bundle\BusinessPageBundle\VictoireBusinessPageBundle(),
                 new Victoire\Bundle\FilterBundle\VictoireFilterBundle(),
@@ -62,6 +61,7 @@ class AppKernel extends Kernel
                 new Victoire\Bundle\ViewReferenceBundle\ViewReferenceBundle(),
                 new Victoire\Bundle\WidgetBundle\VictoireWidgetBundle(),
                 new Victoire\Bundle\WidgetMapBundle\VictoireWidgetMapBundle(),
+                new Victoire\Bundle\BlogBundle\VictoireBlogBundle(),
 
                 //Victoire minimal test bundles
                 new Victoire\Widget\ForceBundle\VictoireWidgetForceBundle(),

--- a/Tests/App/app/AppKernel.php
+++ b/Tests/App/app/AppKernel.php
@@ -67,9 +67,8 @@ class AppKernel extends Kernel
                 new Victoire\Widget\LightSaberBundle\VictoireWidgetLightSaberBundle(),
                 new Victoire\Widget\TextBundle\VictoireWidgetTextBundle(),
 
-                new Victoire\Bundle\BlogBundle\VictoireBlogBundle(),
-
                 new Acme\AppBundle\AcmeAppBundle(),
+                new Victoire\Bundle\BlogBundle\VictoireBlogBundle(),
             ],
             $this->getTestBundles()
         );

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -70,6 +70,8 @@ class AppKernel extends Kernel
             new Victoire\Bundle\ViewReferenceBundle\ViewReferenceBundle(),
             new Victoire\Bundle\WidgetBundle\VictoireWidgetBundle(),
             new Victoire\Bundle\WidgetMapBundle\VictoireWidgetMapBundle(),
+
+            //BlogBundle should be set just before your AppBundle
             new Victoire\Bundle\BlogBundle\VictoireBlogBundle(),
             ...
         ];

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -51,7 +51,6 @@ class AppKernel extends Kernel
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             //Victoire bundles
             new Victoire\Bundle\AnalyticsBundle\VictoireAnalyticsBundle(),
-            new Victoire\Bundle\BlogBundle\VictoireBlogBundle(),
             new Victoire\Bundle\BusinessEntityBundle\VictoireBusinessEntityBundle(),
             new Victoire\Bundle\BusinessPageBundle\VictoireBusinessPageBundle(),
             new Victoire\Bundle\CoreBundle\VictoireCoreBundle(),
@@ -71,6 +70,7 @@ class AppKernel extends Kernel
             new Victoire\Bundle\ViewReferenceBundle\ViewReferenceBundle(),
             new Victoire\Bundle\WidgetBundle\VictoireWidgetBundle(),
             new Victoire\Bundle\WidgetMapBundle\VictoireWidgetMapBundle(),
+            new Victoire\Bundle\BlogBundle\VictoireBlogBundle(),
             ...
         ];
     }


### PR DESCRIPTION
If you keep the current order to load victoire bundles, you get this error during ./bin/console do:sc:cr

[ReflectionException]
  Property Victoire\Bundle\CoreBundle\Entity\EntityProxy::$article does not exist

I put BlogBundle in last, and it solves this issue.

## Type
documentation

## Purpose
This PR improves documentation of setup

## BC Break
NO

