### PR TITLE
Bugfix/blog date filter

### DIFF
--- a/Bundle/BlogBundle/Repository/ArticleRepository.php
+++ b/Bundle/BlogBundle/Repository/ArticleRepository.php
@@ -31,10 +31,10 @@ class ArticleRepository extends EntityRepository
         if ($excludeUnpublished) {
             $this->qb
                 ->andWhere('article.status = :status')
-                ->orWhere('article.status = :scheduled_status AND article.publishedAt > :publicationDate')
+                ->orWhere('article.status = :scheduled_status AND article.publishedAt <= :now')
                 ->setParameter('status', PageStatus::PUBLISHED)
                 ->setParameter('scheduled_status', PageStatus::SCHEDULED)
-                ->setParameter('publicationDate', new \DateTime());
+                ->setParameter('now', new \DateTime());
         }
 
         if (null != $blog) {


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Fixes articles date filter. 
First problem was articles filtered only on publishedAt and that ignore 2 other possible states:
- Articles without publishedAt and only published status
- Articles with publishedAt and published status

Another issue was ArticleRepository return wrong result when published date is scheduled

## BC Break
NO