### PR TITLE
[WIP] Update declaration of ExceptionController::showAction()

### DIFF
--- a/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -2,9 +2,15 @@
 
 namespace Victoire\Bundle\TwigBundle\Controller;
 
+// BC for Symfony ≤ 2.8
+if (class_exists('\Symfony\Component\Debug\Exception\FlattenException')) {
+    class_alias('\Symfony\Component\Debug\Exception\FlattenException', 'FlattenException');
+} else {
+    class_alias('\Symfony\Component\HttpKernel\Exception\FlattenException', 'FlattenException');
+}
+
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\TwigBundle\Controller\ExceptionController as BaseExceptionController;
-use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -65,7 +71,7 @@ class ExceptionController extends BaseExceptionController
      *
      * @return Response
      */
-    public function showAction(Request $request, FlattenException $exception, DebugLoggerInterface $logger = null, $_format = 'html')
+    public function showAction(Request $request, FlattenException $exception, DebugLoggerInterface $logger = null)
     {
         $currentContent = $this->getAndCleanOutputBuffering($request->headers->get('X-Php-Ob-Level', -1));
         $code = $exception->getStatusCode();
@@ -90,7 +96,7 @@ class ExceptionController extends BaseExceptionController
         }
 
         return new Response($this->twig->render(
-            $this->findTemplate($request, $_format, $code, $this->debug),
+            $this->findTemplate($request, 'html', $code, $this->debug),
             [
                 'status_code'    => $code,
                 'status_text'    => isset(Response::$statusTexts[$code]) ? Response::$statusTexts[$code] : '',

--- a/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -3,17 +3,17 @@
 namespace Victoire\Bundle\TwigBundle\Controller;
 
 // BC for Symfony ≤ 2.8
-if (class_exists('\Symfony\Component\Debug\Exception\FlattenException')) {
-    class_alias('\Symfony\Component\Debug\Exception\FlattenException', 'FlattenException');
-} else {
-    class_alias('\Symfony\Component\HttpKernel\Exception\FlattenException', 'FlattenException');
+if (class_exists('Symfony\Component\Debug\Exception\FlattenException')) {
+    class_alias('Symfony\Component\Debug\Exception\FlattenException', 'Symfony\Component\HttpKernel\Exception\FlattenException');
 }
 
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\TwigBundle\Controller\ExceptionController as BaseExceptionController;
+use Symfony\Component\Debug\Exception\FlattenException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\FlattenException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Component\Routing\Router;


### PR DESCRIPTION
## Type
Bugfix: update declaration of a method that doesn't match with the declaration of the method in Symfony.

## Purpose
Fixes an exception:

> Whoops, looks like something went wrong.
> 1/1 ContextErrorException in ExceptionController.php line 18:
> 
> Warning: Declaration of Victoire\Bundle\TwigBundle\Controller\ExceptionController::showAction(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\Debug\Exception\FlattenException $exception, Symfony\Component\HttpKernel\Log\DebugLoggerInterface $logger = NULL, $_format = 'html') should be compatible with Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpKernel\Exception\FlattenException $exception, Symfony\Component\HttpKernel\Log\DebugLoggerInterface $logger = NULL) 

## BC Break
YES if a method inherited this method.