### PR TITLE
[WIP] Compatibility with symfony 3.2.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /Tests/App/app/config/parameters.yml
 /Bundle/UIBundle/Resources/public/bower_components/*
 node_modules
+/.idea

--- a/Bundle/BusinessEntityBundle/Annotation/AnnotationDriver.php
+++ b/Bundle/BusinessEntityBundle/Annotation/AnnotationDriver.php
@@ -83,7 +83,7 @@ class AnnotationDriver extends DoctrineAnnotationDriver
                     new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
                     \RecursiveIteratorIterator::LEAVES_ONLY
                 ),
-                '/^.+\/Entity\/.+\.php$/i',
+                '/^(?!.*Tests).+\/Entity\/.+\.php$/i',
                 \RecursiveRegexIterator::GET_MATCH
             );
             foreach ($iterator as $file) {
@@ -91,16 +91,55 @@ class AnnotationDriver extends DoctrineAnnotationDriver
                 $includedFiles[] = $sourceFile;
             }
         }
-        $declared = get_declared_classes();
-        foreach ($declared as $className) {
-            $rc = new \ReflectionClass($className);
-            $sourceFile = $rc->getFileName();
-            if (in_array($sourceFile, $includedFiles) && !$this->isTransient($className)) {
-                $classes[] = $className;
-            }
+
+        foreach ($includedFiles as $fileName) {
+            $classes[] = $this->getClassNameFromFile($fileName);
         }
 
         return $classes;
+    }
+
+
+    /**
+     *  get_declared_classes doesn't list anymore all classes since issue #23014 of Symfony
+     *  I suggest using tokenizer. Faster than including or requiring all the files
+     *  Function recovered on http://jarretbyrne.com/2015/06/197/ Thank you to him
+     *  @return string
+     */
+    private function getClassNameFromFile($filepath)
+    {
+        $contents = file_get_contents($filepath);
+        $namespace = $class = "";
+        $getting_namespace = $getting_class = false;
+        foreach (token_get_all($contents) as $token) {
+
+            if (is_array($token) && $token[0] == T_NAMESPACE) {
+                $getting_namespace = true;
+            }
+
+            if (is_array($token) && in_array($token[0], [T_CLASS, T_TRAIT, T_INTERFACE])) {
+                $getting_class = true;
+            }
+
+            if ($getting_namespace === true) {
+
+                if(is_array($token) && in_array($token[0], [T_STRING, T_NS_SEPARATOR])) {
+                    $namespace .= $token[1];
+                }
+                else if ($token === ';') {
+                    $getting_namespace = false;
+                }
+            }
+
+            if ($getting_class === true) {
+
+                if(is_array($token) && $token[0] == T_STRING) {
+                    $class = $token[1];
+                    break;
+                }
+            }
+        }
+        return $namespace ? $namespace . '\\' . $class : $class;
     }
 
     /**

--- a/Bundle/BusinessEntityBundle/Annotation/AnnotationDriver.php
+++ b/Bundle/BusinessEntityBundle/Annotation/AnnotationDriver.php
@@ -93,7 +93,10 @@ class AnnotationDriver extends DoctrineAnnotationDriver
         }
 
         foreach ($includedFiles as $fileName) {
-            $classes[] = $this->getClassNameFromFile($fileName);
+            $class = $this->getClassNameFromFile($fileName);
+            if (class_exists($class) && !$this->isTransient($class)) {
+                $classes[] = $class;
+            }
         }
 
         return $classes;

--- a/Bundle/BusinessEntityBundle/Annotation/AnnotationDriver.php
+++ b/Bundle/BusinessEntityBundle/Annotation/AnnotationDriver.php
@@ -104,12 +104,13 @@ class AnnotationDriver extends DoctrineAnnotationDriver
      *  get_declared_classes doesn't list anymore all classes since issue #23014 of Symfony
      *  I suggest using tokenizer. Faster than including or requiring all the files
      *  Function recovered on http://jarretbyrne.com/2015/06/197/ Thank you to him
+     *
      *  @return string
      */
     private function getClassNameFromFile($filepath)
     {
         $contents = file_get_contents($filepath);
-        $namespace = $class = "";
+        $namespace = $class = '';
         $getting_namespace = $getting_class = false;
         foreach (token_get_all($contents) as $token) {
 
@@ -123,23 +124,22 @@ class AnnotationDriver extends DoctrineAnnotationDriver
 
             if ($getting_namespace === true) {
 
-                if(is_array($token) && in_array($token[0], [T_STRING, T_NS_SEPARATOR])) {
+                if (is_array($token) && in_array($token[0], [T_STRING, T_NS_SEPARATOR])) {
                     $namespace .= $token[1];
-                }
-                else if ($token === ';') {
+                } else if ($token === ';') {
                     $getting_namespace = false;
                 }
             }
 
             if ($getting_class === true) {
 
-                if(is_array($token) && $token[0] == T_STRING) {
+                if (is_array($token) && $token[0] == T_STRING) {
                     $class = $token[1];
                     break;
                 }
             }
         }
-        return $namespace ? $namespace . '\\' . $class : $class;
+        return $namespace ? $namespace.'\\'.$class : $class;
     }
 
     /**

--- a/Bundle/BusinessEntityBundle/Annotation/AnnotationDriver.php
+++ b/Bundle/BusinessEntityBundle/Annotation/AnnotationDriver.php
@@ -99,7 +99,6 @@ class AnnotationDriver extends DoctrineAnnotationDriver
         return $classes;
     }
 
-
     /**
      *  get_declared_classes doesn't list anymore all classes since issue #23014 of Symfony
      *  I suggest using tokenizer. Faster than including or requiring all the files
@@ -113,7 +112,6 @@ class AnnotationDriver extends DoctrineAnnotationDriver
         $namespace = $class = '';
         $getting_namespace = $getting_class = false;
         foreach (token_get_all($contents) as $token) {
-
             if (is_array($token) && $token[0] == T_NAMESPACE) {
                 $getting_namespace = true;
             }
@@ -123,7 +121,6 @@ class AnnotationDriver extends DoctrineAnnotationDriver
             }
 
             if ($getting_namespace === true) {
-
                 if (is_array($token) && in_array($token[0], [T_STRING, T_NS_SEPARATOR])) {
                     $namespace .= $token[1];
                 } elseif ($token === ';') {
@@ -132,13 +129,13 @@ class AnnotationDriver extends DoctrineAnnotationDriver
             }
 
             if ($getting_class === true) {
-
                 if (is_array($token) && $token[0] == T_STRING) {
                     $class = $token[1];
                     break;
                 }
             }
         }
+
         return $namespace ? $namespace.'\\'.$class : $class;
     }
 

--- a/Bundle/BusinessEntityBundle/Annotation/AnnotationDriver.php
+++ b/Bundle/BusinessEntityBundle/Annotation/AnnotationDriver.php
@@ -103,7 +103,7 @@ class AnnotationDriver extends DoctrineAnnotationDriver
     /**
      *  get_declared_classes doesn't list anymore all classes since issue #23014 of Symfony
      *  I suggest using tokenizer. Faster than including or requiring all the files
-     *  Function recovered on http://jarretbyrne.com/2015/06/197/ Thank you to him
+     *  Function recovered on http://jarretbyrne.com/2015/06/197/ Thank you to him.
      *
      *  @return string
      */
@@ -126,7 +126,7 @@ class AnnotationDriver extends DoctrineAnnotationDriver
 
                 if (is_array($token) && in_array($token[0], [T_STRING, T_NS_SEPARATOR])) {
                     $namespace .= $token[1];
-                } else if ($token === ';') {
+                } elseif ($token === ';') {
                     $getting_namespace = false;
                 }
             }

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "symfony/assetic-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4|~3.0",
         "symfony/polyfill-apcu": "^1.0",
-        "symfony/symfony": "^2.8|^3.0,<3.2.10",
+        "symfony/symfony": "^2.8|^3.0,<3.3.0",
         "symfony/swiftmailer-bundle": "^2.3",
         "troopers/alertify-bundle": "^3.0",
         "troopers/assetic-injector-bundle": "^1.1",


### PR DESCRIPTION
 I suggest using tokenizer instead of get_declared_classes
 I think that the function getClassNameFromFile should be tested

## Type
Bugfix

## Purpose
<!-- If bugfix -->
Fixes #951

## BC Break
YES|NO

<!-- If YES -->
This PR breaks (this|that)
