### PR TITLE
Fix error "Widget […] name is already in use"

### DIFF
--- a/Bundle/WidgetBundle/Model/WidgetManager.php
+++ b/Bundle/WidgetBundle/Model/WidgetManager.php
@@ -21,7 +21,6 @@ use Victoire\Bundle\CoreBundle\VictoireCmsEvents;
 use Victoire\Bundle\FormBundle\Helper\FormErrorHelper;
 use Victoire\Bundle\PageBundle\Helper\PageHelper;
 use Victoire\Bundle\WidgetBundle\Builder\WidgetFormBuilder;
-use Victoire\Bundle\WidgetBundle\Entity\Widget;
 use Victoire\Bundle\WidgetBundle\Helper\WidgetHelper;
 use Victoire\Bundle\WidgetBundle\Renderer\WidgetRenderer;
 use Victoire\Bundle\WidgetBundle\Resolver\WidgetContentResolver;


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Fixes a fatal error that occurs only on PHP 7.0.4-7ubuntu2.1:

> PHP Fatal error:  Cannot use Victoire\\Bundle\\WidgetBundle\\Entity\\Widget as Widget because the name is already in use in /…/vendor/victoire/victoire/Bundle/WidgetBundle/Model/WidgetManager.php on line 23,

## BC Break
NO
