### PR TITLE
Update "symfony/twig-bundle" to "~3.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
         "symfony/polyfill-apcu": "^1.0",
         "symfony/symfony": "^2.8|^3.0,<3.2.10",
         "symfony/swiftmailer-bundle": "^2.3",
+        "symfony/twig-bundle": "~3.0",
         "troopers/alertify-bundle": "^3.0",
         "troopers/assetic-injector-bundle": "^1.1",
         "twig/extensions": "~1.0",


### PR DESCRIPTION
Fix error with uncompatible declaration of
`Victoire\Bundle\TwigBundle\Controller\ExceptionController::showAction()`

## Type
Bugfix

## Purpose
Fixes an exception that occured with Symfony 2.8:

> Whoops, looks like something went wrong.
> 1/1 ContextErrorException in ExceptionController.php line 18:
> 
> Warning: Declaration of Victoire\Bundle\TwigBundle\Controller\ExceptionController::showAction(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\Debug\Exception\FlattenException $exception, Symfony\Component\HttpKernel\Log\DebugLoggerInterface $logger = NULL, $_format = 'html') should be compatible with Symfony\Bundle\TwigBundle\Controller\ExceptionController::showAction(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpKernel\Exception\FlattenException $exception, Symfony\Component\HttpKernel\Log\DebugLoggerInterface $logger = NULL) 

See https://github.com/Victoire/victoire/pull/958#issuecomment-317805819 for further explanation.

It replaces #958

## BC Break
NO