### PR TITLE
Add import in Twig macro

### DIFF
--- a/Bundle/TemplateBundle/Resources/views/Template/index.html.twig
+++ b/Bundle/TemplateBundle/Resources/views/Template/index.html.twig
@@ -26,6 +26,7 @@
 {% endblock modal_body_content %}
 
 {% macro templatesHierarchy(templates) %}
+    {% import _self as macros %}
     {% for template in templates %}
         <li class="v-list-group__item" id="list_{{ template.id }}">
             <div class="v-flex-grid v-flex-grid--justify-between v-flex-grid--align-center">


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Exception message:

> An exception has been thrown during the rendering of a template (&quot;Notice: Undefined index: macros&quot;)

According to [Twig documentation](https://twig.symfony.com/doc/2.x/tags/macro.html):

> When you want to use a macro in another macro from the same file, you need to import it locally

So I added a use in the macro.

## BC Break
NO