### PR TITLE
Avoid error when a widget call a missing property

### DIFF
--- a/Bundle/BusinessEntityBundle/Entity/Traits/BusinessEntityTrait.php
+++ b/Bundle/BusinessEntityBundle/Entity/Traits/BusinessEntityTrait.php
@@ -81,6 +81,11 @@ trait BusinessEntityTrait
         if ($field) {
             $functionName = 'get'.ucfirst($field);
 
+            // Avoid error when the widget refer to a property that has been removed
+            if (!method_exists($this, $functionName)) {
+                return;
+            }
+
             $fieldValue = $this->{$functionName}();
         } else {
             $fieldValue = null;


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Fixes exception that break page rendering when a widget call a property that doesn't exist.

## BC Break
NO
