### PR TITLE
exclude vendors from codacy

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,5 @@
+exclude_paths:
+  - Bundle/CoreBundle/Resources/public/js/vic-intercooler.js
+  - Bundle/MediaBundle/Resources/public/js/ckeditor/**
+  - Bundle/MediaBundle/Resources/public/js/libs/**
+  - Bundle/FormBundle/Resources/public/components/**


### PR DESCRIPTION
## Type
Bugfix

## Purpose

fix codacy checkstyle by excluding external vendors