### PR TITLE
WIP:Fix/repair redirections and notification display

### DIFF
--- a/Bundle/CoreBundle/Resources/style/less/ugly.less
+++ b/Bundle/CoreBundle/Resources/style/less/ugly.less
@@ -133,3 +133,7 @@
     text-decoration: none;
     background-color: #333;
 }
+
+.vic-ns-box {
+    z-index: 2000 !important;
+}

--- a/Bundle/CoreBundle/Resources/style/less/ugly.less
+++ b/Bundle/CoreBundle/Resources/style/less/ugly.less
@@ -138,6 +138,6 @@
     z-index: 2000 !important;
 }
 
-.collapse {
-    display: none !important;
+.d-none {
+    display: none;
 }

--- a/Bundle/CoreBundle/Resources/style/less/ugly.less
+++ b/Bundle/CoreBundle/Resources/style/less/ugly.less
@@ -137,3 +137,7 @@
 .vic-ns-box {
     z-index: 2000 !important;
 }
+
+.collapse {
+    display: none !important;
+}

--- a/Bundle/PageBundle/Handler/RedirectionHandler.php
+++ b/Bundle/PageBundle/Handler/RedirectionHandler.php
@@ -5,7 +5,6 @@ namespace Victoire\Bundle\PageBundle\Handler;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\NoResultException;
 use Victoire\Bundle\SeoBundle\Entity\Error404;
-use Victoire\Bundle\SeoBundle\Entity\ErrorRedirection;
 use Victoire\Bundle\SeoBundle\Entity\Redirection;
 
 /**
@@ -44,7 +43,7 @@ class RedirectionHandler
             $this->increaseCounter($redirection);
 
             return $redirection;
-        } else if ($error404) {
+        } elseif ($error404) {
             $this->increaseCounter($error404);
 
             return $error404;

--- a/Bundle/PageBundle/Handler/RedirectionHandler.php
+++ b/Bundle/PageBundle/Handler/RedirectionHandler.php
@@ -5,6 +5,7 @@ namespace Victoire\Bundle\PageBundle\Handler;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\NoResultException;
 use Victoire\Bundle\SeoBundle\Entity\Error404;
+use Victoire\Bundle\SeoBundle\Entity\ErrorRedirection;
 use Victoire\Bundle\SeoBundle\Entity\Redirection;
 
 /**
@@ -30,30 +31,35 @@ class RedirectionHandler
     /**
      * Check if the Error and its associated Redirection exists, then increase the counter of the Error|Redirection.
      *
-     * @param Error404 $error
+     * @param Redirection|null $redirection
+     * @param Error404|null    $error404
      *
      * @throws NoResultException
      *
-     * @return Error404|Redirection
+     * @return Redirection|Error404
      */
-    public function handleError($error)
+    public function handleError($redirection, $error404)
     {
-        if ($error) {
-            $redirection = $error->getRedirection();
-
-            if ($redirection) {
-                $redirection->increaseCounter();
-                $this->entityManager->flush();
-            } else {
-                $error->increaseCounter();
-                $this->entityManager->flush();
-
-                return $error;
-            }
+        if ($redirection) {
+            $this->increaseCounter($redirection);
 
             return $redirection;
+        } else if ($error404) {
+            $this->increaseCounter($error404);
+
+            return $error404;
         }
 
         throw new NoResultException();
+    }
+
+    /**
+     * @param Redirection|Error404 $object
+     */
+    private function increaseCounter($object)
+    {
+        $object->increaseCounter();
+
+        $this->entityManager->flush();
     }
 }

--- a/Bundle/PageBundle/Helper/PageHelper.php
+++ b/Bundle/PageBundle/Helper/PageHelper.php
@@ -200,7 +200,7 @@ class PageHelper
                     return new RedirectResponse($this->container->get('victoire_widget.twig.link_extension')->victoireLinkUrl(
                         $result->getLink()->getParameters()
                     ));
-                } else if ($result->getRedirection()) {
+                } elseif ($result->getRedirection()) {
                     return new RedirectResponse($this->container->get('victoire_widget.twig.link_extension')->victoireLinkUrl(
                         $result->getRedirection()->getLink()->getParameters()
                     ));

--- a/Bundle/PageBundle/Helper/PageHelper.php
+++ b/Bundle/PageBundle/Helper/PageHelper.php
@@ -189,14 +189,21 @@ class PageHelper
             return $this->renderPage($page, $layout);
         } else {
             try {
-                /** @var Error404 $error */
-                $error = $this->entityManager->getRepository('VictoireSeoBundle:Error404')->findOneBy(['url' => $uri]);
-                if ($this->redirectionHelper->handleError($error) instanceof Redirection) {
-                    return new RedirectResponse(
-                        $this->container->get('victoire_widget.twig.link_extension')->victoireLinkUrl(
-                            $error->getRedirection()->getLink()->getParameters()
-                        )
-                    );
+                /** @var Error404 $error404 */
+                $error404 = $this->entityManager->getRepository('VictoireSeoBundle:Error404')->findOneBy(['url' => $uri]);
+                /** @var Redirection $redirection */
+                $redirection = $this->entityManager->getRepository('VictoireSeoBundle:Redirection')->findOneBy(['url' => $uri]);
+
+                $result = $this->redirectionHelper->handleError($redirection, $error404);
+
+                if ($result instanceof Redirection) {
+                    return new RedirectResponse($this->container->get('victoire_widget.twig.link_extension')->victoireLinkUrl(
+                        $result->getLink()->getParameters()
+                    ));
+                } else if ($result->getRedirection()) {
+                    return new RedirectResponse($this->container->get('victoire_widget.twig.link_extension')->victoireLinkUrl(
+                        $result->getRedirection()->getLink()->getParameters()
+                    ));
                 }
             } catch (NoResultException $e) {
                 $error = new Error404();

--- a/Bundle/SeoBundle/Resources/views/Error404/_preview.html.twig
+++ b/Bundle/SeoBundle/Resources/views/Error404/_preview.html.twig
@@ -14,7 +14,7 @@
            data-confirm-callback="$vic('#delete-link-{{ error.id }}').trigger('confirmed-by-user')"
         >
             <i class="fa fa-times"></i>
-            <i class="fa fa-spinner fa-spin v-ic-indicator collapse"></i>
+            <i class="fa fa-spinner fa-spin v-ic-indicator d-none"></i>
         </a>
     </div>
     <div class="col-md-7 col-sm-12 col-sm-align-center col-sm-mt-1">


### PR DESCRIPTION
Override .ns-box z-index (from 1002 to 2000) in order to put the notification box in the foreground, actually displayed under Victoire's left menu.

Repair the redirection process in PageHelper class, wich does not work actually when the redirection is not created from a 404 error.