### PR TITLE
Bugfix: Fix typo in CategoryFilter

### DIFF
--- a/Bundle/BlogBundle/Filter/CategoryFilter.php
+++ b/Bundle/BlogBundle/Filter/CategoryFilter.php
@@ -109,7 +109,7 @@ class CategoryFilter extends BaseFilter
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $categories = $this->filterQueryHandler->handle($options['widget'], BlogCategory::class);
+        $categories = $this->filterQueryHandler->handle($options['widget'], Category::class);
 
         $categoriesChoices = [];
 


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Fixes exception:

>  Class 'Victoire\Bundle\BlogBundle\Filter\BlogCategory' does not exist 

## BC Break
NO
