### PR TITLE
Feature #1010: Increase “metaDescription” length to 230

### DIFF
--- a/Bundle/SeoBundle/Entity/PageSeo.php
+++ b/Bundle/SeoBundle/Entity/PageSeo.php
@@ -40,7 +40,7 @@ class PageSeo
      * @var string
      *
      * @ORM\Column(name="meta_description", type="string", length=255, nullable=true)
-     * @Assert\Length(max = 155)
+     * @Assert\Length(max = 230)
      */
     protected $metaDescription;
 


### PR DESCRIPTION
## Type
Feature

## Purpose
Fixes #1010

## BC Break
NO