### PR TITLE
Feature #1010: Increase “metaDescription” length to 230

### DIFF
--- a/Bundle/SeoBundle/Entity/PageSeoTranslation.php
+++ b/Bundle/SeoBundle/Entity/PageSeoTranslation.php
@@ -33,7 +33,7 @@ class PageSeoTranslation
      * @var string
      *
      * @ORM\Column(name="meta_description", type="string", length=255, nullable=true)
-     * @Assert\Length(max = 155)
+     * @Assert\Length(max = 230)
      */
     protected $metaDescription;
 


### PR DESCRIPTION
## Type
Feature

Same as #1019.

## Purpose
Fixes #1010

## BC Break
NO