### PR TITLE
CircleCI: Use PHP 7.1.9, avoid bug with doctrine/orm 2.6

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
   services:
     - redis
   php:
-    version: 7.0.7
+    version: 7.1.9
 
 checkout:
   post:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "a2lix/translation-form-bundle": "^2.1",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-migrations-bundle": "^1.2",
-        "doctrine/orm": "^2.5",
+        "doctrine/orm": "^2.5,<2.6",
         "friendsofsymfony/jsrouting-bundle": "^1.0|^2.0",
         "friendsofsymfony/user-bundle": "~2.0",
         "incenteev/composer-parameter-handler": "^2.0",


### PR DESCRIPTION
## Type
Feature

## Purpose
Upgrade version of PHP used on CircleCI.

## BC Break
NO

Same as #1022.