### PR TITLE
[on hold] Fix test assertion was true wis begining condition

### DIFF
--- a/Bundle/WidgetBundle/Model/WidgetManager.php
+++ b/Bundle/WidgetBundle/Model/WidgetManager.php
@@ -407,10 +407,11 @@ class WidgetManager
             $this->entityManager->remove($widget);
         }
 
-        //we update the view
-        $this->entityManager->persist($view);
         //update the view deleting the widget
         $this->widgetMapManager->delete($view, $widget);
+
+        //we update the view
+        $this->entityManager->persist($view);
 
         $this->entityManager->flush();
 

--- a/Tests/Features/WidgetMap/widgetMapTemplate.feature
+++ b/Tests/Features/WidgetMap/widgetMapTemplate.feature
@@ -137,6 +137,7 @@ Feature: Test widgetMap
         Given I press "YES, I WANT TO DELETE IT!"
         And I reload the page
         And "Widget 3" should precede "Widget 2"
+        And I should not see "Widget 1"
         Then I am on "/en/victoire-dcms/template/show/1"
         And "Widget 1" should precede "Widget 3"
         And "Widget 3" should precede "Widget 2"


### PR DESCRIPTION
> Inverse method order to avoid error when flushing non-persisted element
> 
> ## Type
> Bugfix
> 
> ## Purpose
> Change method call order to avoid error when persisting a view with a new widget map
> 
> ## BC Break
> NO

Replaces #982.