### PR TITLE
[WIP] Fix bug with widget inheritance

### DIFF
--- a/Bundle/WidgetBundle/Model/WidgetManager.php
+++ b/Bundle/WidgetBundle/Model/WidgetManager.php
@@ -391,13 +391,12 @@ class WidgetManager
      * Remove a widget.
      *
      * @param Widget $widget
+     * @param View   $view
      *
-     * @return array The parameter for the view
+     * @return void
      */
     public function deleteWidget(Widget $widget, View $view)
     {
-        //Used to update view in callback (we do it before delete it else it'll not exists anymore)
-        $widgetId = $widget->getId();
         //we update the widget map of the view
         $this->widgetMapBuilder->build($view);
         $widgetMap = $widget->getWidgetMap();
@@ -413,12 +412,6 @@ class WidgetManager
         $this->widgetMapManager->delete($view, $widget);
 
         $this->entityManager->flush();
-
-        return [
-            'success'     => true,
-            'widgetId'    => $widgetId,
-            'viewCssHash' => $view->getCssHash(),
-        ];
     }
 
     /**

--- a/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
+++ b/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
@@ -132,6 +132,8 @@ class WidgetMapManager
         $beforeChild = !empty($children[WidgetMap::POSITION_BEFORE]) ? $children[WidgetMap::POSITION_BEFORE] : null;
         $afterChild = !empty($children[WidgetMap::POSITION_AFTER]) ? $children[WidgetMap::POSITION_AFTER] : null;
 
+        $replaceWidgetMap = null;
+
         //we remove the widget from the current view
         if ($widgetMap->getView() === $view) {
             // If the widgetMap has substitutes, delete them or transform them in create mode
@@ -162,9 +164,11 @@ class WidgetMapManager
         //Move children for current WidgetMap View
         $this->moveChildren($view, $beforeChild, $afterChild, $originalParent, $originalPosition);
 
-        //Move children WidgetMap for children from other View
-        foreach ($widgetMap->getChildren() as $child) {
-            $this->moveWidgetMap($child->getView(), $child, $originalParent, $originalPosition);
+        // Move children WidgetMap for children from other View
+        if (null === $replaceWidgetMap) {
+            foreach ($widgetMap->getChildren() as $child) {
+                $this->moveWidgetMap($child->getView(), $child, $originalParent, $originalPosition);
+            }
         }
     }
 

--- a/Tests/Features/WidgetMap/widgetMapTemplate.feature
+++ b/Tests/Features/WidgetMap/widgetMapTemplate.feature
@@ -131,14 +131,19 @@ Feature: Test widgetMap
         Then I should see "Widget 1"
         When I switch to "edit" mode
         And I edit the "Text" widget
-        Then I should see "DELETE"
+        Then I should see "Widget #1 (Plain Text)"
+        And I should see "This content is owned by a parent template"
+        And I should see "DELETE"
         Given I follow "DELETE"
         Then I should see "This action will permanently delete this content from the database. This action is irreversible."
         Given I press "YES, I WANT TO DELETE IT!"
         And I reload the page
-        And "Widget 3" should precede "Widget 2"
-        Then I am on "/en/victoire-dcms/template/show/1"
-        And "Widget 1" should precede "Widget 3"
+        Then "Widget 3" should precede "Widget 2"
+        # Widget 1 has been removed from this view
+        And I should not see "Widget 1"
+        # Check that base template hasn't been changed
+        Given I am on "/en/victoire-dcms/template/show/1"
+        Then "Widget 1" should precede "Widget 3"
         And "Widget 3" should precede "Widget 2"
 
     Scenario: I overwrite a widget from template


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Fixes bug with widget map inheritance: when we removed a widget, it also removed it from the parent template.

This is an independent solution I found while working on #1024.

## BC Break
NO

May replace #982 and #1033.

