### PR TITLE
Fix test assertion was true with beginning condition

### DIFF
--- a/Bundle/WidgetBundle/Model/WidgetManager.php
+++ b/Bundle/WidgetBundle/Model/WidgetManager.php
@@ -406,10 +406,11 @@ class WidgetManager
             $this->entityManager->remove($widget);
         }
 
-        //we update the view
-        $this->entityManager->persist($view);
         //update the view deleting the widget
         $this->widgetMapManager->delete($view, $widget);
+
+        //we update the view
+        $this->entityManager->persist($view);
 
         $this->entityManager->flush();
     }

--- a/Bundle/WidgetMapBundle/Entity/WidgetMap.php
+++ b/Bundle/WidgetMapBundle/Entity/WidgetMap.php
@@ -70,7 +70,7 @@ class WidgetMap
 
     /**
      * @var ArrayCollection
-     * @ORM\OneToMany(targetEntity="\Victoire\Bundle\WidgetMapBundle\Entity\WidgetMap", mappedBy="replaced")
+     * @ORM\OneToMany(targetEntity="\Victoire\Bundle\WidgetMapBundle\Entity\WidgetMap", mappedBy="replaced", cascade={"persist"}))
      */
     protected $substitutes;
 

--- a/Bundle/WidgetMapBundle/Entity/WidgetMap.php
+++ b/Bundle/WidgetMapBundle/Entity/WidgetMap.php
@@ -109,7 +109,7 @@ class WidgetMap
 
     public function __toString()
     {
-        return $value = (string) $this->id;
+        return (string) $this->id;
     }
 
     public function __construct()

--- a/Bundle/WidgetMapBundle/Entity/WidgetMap.php
+++ b/Bundle/WidgetMapBundle/Entity/WidgetMap.php
@@ -70,7 +70,7 @@ class WidgetMap
 
     /**
      * @var ArrayCollection
-     * @ORM\OneToMany(targetEntity="\Victoire\Bundle\WidgetMapBundle\Entity\WidgetMap", mappedBy="replaced", cascade={"persist"}))
+     * @ORM\OneToMany(targetEntity="\Victoire\Bundle\WidgetMapBundle\Entity\WidgetMap", mappedBy="replaced")
      */
     protected $substitutes;
 
@@ -106,6 +106,11 @@ class WidgetMap
      * @ORM\Column(name="slot", type="string", length=255, nullable=true)
      */
     protected $slot;
+
+    public function __toString()
+    {
+        return $value = (string) $this->id;
+    }
 
     public function __construct()
     {

--- a/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
+++ b/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
@@ -164,7 +164,7 @@ class WidgetMapManager
 
         //Move children WidgetMap for children from other View
         foreach ($widgetMap->getChildren() as $child) {
-            if ($child->getView()->getParent() === $view) {
+            if ($child->getView() === $view || $child->getView()->getTemplate() === $view) {
                 $this->moveWidgetMap($child->getView(), $child, $originalParent, $originalPosition);
             }
         }

--- a/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
+++ b/Bundle/WidgetMapBundle/Manager/WidgetMapManager.php
@@ -164,7 +164,9 @@ class WidgetMapManager
 
         //Move children WidgetMap for children from other View
         foreach ($widgetMap->getChildren() as $child) {
-            $this->moveWidgetMap($child->getView(), $child, $originalParent, $originalPosition);
+            if ($child->getView()->getParent() === $view) {
+                $this->moveWidgetMap($child->getView(), $child, $originalParent, $originalPosition);
+            }
         }
     }
 

--- a/Tests/Features/WidgetMap/widgetMapTemplate.feature
+++ b/Tests/Features/WidgetMap/widgetMapTemplate.feature
@@ -131,12 +131,14 @@ Feature: Test widgetMap
         Then I should see "Widget 1"
         When I switch to "edit" mode
         And I edit the "Text" widget
-        Then I should see "DELETE"
+        Then I should see "Widget 1"
+        And I should see "DELETE"
         Given I follow "DELETE"
         Then I should see "This action will permanently delete this content from the database. This action is irreversible."
         Given I press "YES, I WANT TO DELETE IT!"
         And I reload the page
         And "Widget 3" should precede "Widget 2"
+        And I should not see "Widget 1"
         Then I am on "/en/victoire-dcms/template/show/1"
         And "Widget 1" should precede "Widget 3"
         And "Widget 3" should precede "Widget 2"

--- a/Tests/Features/WidgetMap/widgetMapTemplate.feature
+++ b/Tests/Features/WidgetMap/widgetMapTemplate.feature
@@ -355,6 +355,7 @@ Feature: Test widgetMap
         And I should not see "Widget 4"
         When I switch to "edit" mode
         And I press the "Widget 2" content
+        And I wait 5 second
         Then I should see "DELETE"
         When I follow "DELETE"
         Then I should see "This action will permanently delete this content from the database. This action is irreversible."


### PR DESCRIPTION
> Inverse method order to avoid error when flushing non-persisted element
> 
> ## Type
> Bugfix
> 
> ## Purpose
> Change method call order to avoid error when persisting a view with a new widget map
> 
> ## BC Break
> NO

Replaces #982.