### PR TITLE
Add CLI to generate sitemap

### DIFF
--- a/Bundle/SitemapBundle/Command/GenerateCommand.php
+++ b/Bundle/SitemapBundle/Command/GenerateCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Victoire\Bundle\SitemapBundle\Command;
+
+use Predis\Client;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Victoire\Bundle\SitemapBundle\Domain\Export\SitemapExportHandler;
+
+class GenerateCommand extends ContainerAwareCommand
+{
+    private $redis;
+    private $handler;
+    private $locales;
+
+    public function __construct(Client $redis, SitemapExportHandler $handler, array $locales)
+    {
+        parent::__construct();
+
+        $this->redis = $redis;
+        $this->handler = $handler;
+        $this->locales = $locales;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('victoire:generate:sitemap')
+            ->setDescription('Generate sitemap in cache');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        foreach ($this->locales as $locale) {
+            $pages = $this->handler->handle($locale);
+            $this->redis->set("sitemap.$locale", $this->handler->serialize($pages));
+        }
+    }
+}

--- a/Bundle/SitemapBundle/Controller/SitemapController.php
+++ b/Bundle/SitemapBundle/Controller/SitemapController.php
@@ -28,12 +28,22 @@ class SitemapController extends Controller
      */
     public function xmlAction(Request $request)
     {
-        $pages = $this->get('victoire_sitemap.export.handler')->handle(
-            $request->getLocale()
-        );
+        $redis = $this->get('snc_redis.victoire_client');
+        $locale = $request->getLocale();
+        $cacheKey = "sitemap.$locale";
+
+        if ($redis->exists($cacheKey)) {
+            $pages = $redis->get($cacheKey);
+        } else {
+            $export = $this->get('victoire_sitemap.export.handler');
+
+            $pages = $export->serialize(
+                $export->handle($locale)
+            );
+        }
 
         return $this->render('VictoireSitemapBundle:Sitemap:sitemap.xml.twig', [
-            'pages' => $pages,
+            'pages' => json_decode($pages),
         ]);
     }
 

--- a/Bundle/SitemapBundle/Domain/Export/SitemapExportHandler.php
+++ b/Bundle/SitemapBundle/Domain/Export/SitemapExportHandler.php
@@ -82,6 +82,24 @@ class SitemapExportHandler
         return array_merge($pages, $this->getBusinessPages($tree));
     }
 
+    public function serialize($pages)
+    {
+        $data = [];
+
+        foreach ($pages as $page) {
+            $seo = $page->getSeo();
+
+            $data[] = [
+                'url'               => $page->getUrl(),
+                'publishedAt'       => $page->getPublishedAt()->format('c'),
+                'sitemapChangeFreq' => $seo === null ? 'monthly' : $seo->getSitemapChangeFreq(),
+                'sitemapPriority'   => $seo === null ? 0.5 : $seo->getSitemapPriority(),
+            ];
+        }
+
+        return json_encode($data);
+    }
+
     /**
      * Get all VirtualBusinessPage recursively.
      *

--- a/Bundle/SitemapBundle/Resources/config/services.yml
+++ b/Bundle/SitemapBundle/Resources/config/services.yml
@@ -27,3 +27,13 @@ services:
         arguments: ["@victoire_core.admin_menu_builder"]
         tags:
             - { name: kernel.event_listener, event: victoire_core.build_menu, method: addGlobal, priority: 70 }
+
+    #  ================== COMMAND ================== #
+    victoire_sitemap.command.generate:
+        class: Victoire\Bundle\SitemapBundle\Command\GenerateCommand
+        arguments:
+            - '@snc_redis.victoire_client'
+            - '@victoire_sitemap.export.handler'
+            - '%victoire_i18n.available_locales%'
+        tags:
+            - { name: 'console.command' }

--- a/Bundle/SitemapBundle/Resources/views/Sitemap/sitemap.xml.twig
+++ b/Bundle/SitemapBundle/Resources/views/Sitemap/sitemap.xml.twig
@@ -3,9 +3,9 @@
 {% for page in pages %}
    <url>
       <loc>{{ url('victoire_core_page_show', {'url': page.url}) }}</loc>
-      <lastmod>{{ page.publishedAt|date('c') }}</lastmod>
-      <changefreq>{{ page.seo|default({'sitemapChangeFreq': 'monthly'}).sitemapChangeFreq }}</changefreq>
-      <priority>{{ page.seo|default({'sitemapPriority': 0.5}).sitemapPriority }}</priority>
+      <lastmod>{{ page.publishedAt }}</lastmod>
+      <changefreq>{{ page.sitemapChangeFreq }}</changefreq>
+      <priority>{{ page.sitemapPriority }}</priority>
    </url>
 {% endfor %}
 </urlset>


### PR DESCRIPTION
## Type
Bugfix

## Purpose
On a site with many pages, the sitemap may take more than 30 seconds to generate. This PR adds a CLI command to store the content of the sitemap in redis.

## BC Break
NO