### PR TITLE
Fix issues with sitemap export

### DIFF
--- a/Bundle/SitemapBundle/Domain/Export/SitemapExportHandler.php
+++ b/Bundle/SitemapBundle/Domain/Export/SitemapExportHandler.php
@@ -3,6 +3,7 @@
 namespace Victoire\Bundle\SitemapBundle\Domain\Export;
 
 use Doctrine\ORM\EntityManager;
+use Victoire\Bundle\BusinessPageBundle\Entity\BusinessTemplate;
 use Victoire\Bundle\CoreBundle\Entity\WebViewInterface;
 use Victoire\Bundle\PageBundle\Helper\PageHelper;
 use Victoire\Bundle\ViewReferenceBundle\Connector\ViewReferenceRepository;
@@ -87,14 +88,24 @@ class SitemapExportHandler
         $data = [];
 
         foreach ($pages as $page) {
+            // BusinessTemplate have no getUrl() method
+            if ($page instanceof BusinessTemplate) {
+                continue;
+            }
+
             $seo = $page->getSeo();
 
             $data[] = [
                 'url'               => $page->getUrl(),
-                'publishedAt'       => $page->getPublishedAt()->format('c'),
                 'sitemapChangeFreq' => $seo === null ? 'monthly' : $seo->getSitemapChangeFreq(),
                 'sitemapPriority'   => $seo === null ? 0.5 : $seo->getSitemapPriority(),
             ];
+
+            // This data is optional in sitemap, add it only if a publication date is available
+            // see https://www.sitemaps.org/protocol.html#xmlTagDefinitions
+            if (null !== $page->getPublishedAt() and $page->getPublishedAt() instanceof \DateTime) {
+                $data['publishedAt'] = $page->getPublishedAt()->format('c');
+            }
         }
 
         return json_encode($data);

--- a/Bundle/SitemapBundle/Resources/views/Sitemap/sitemap.xml.twig
+++ b/Bundle/SitemapBundle/Resources/views/Sitemap/sitemap.xml.twig
@@ -3,7 +3,7 @@
 {% for page in pages %}
    <url>
       <loc>{{ url('victoire_core_page_show', {'url': page.url}) }}</loc>
-      <lastmod>{{ page.publishedAt }}</lastmod>
+      {{ if page.publishedAt }}<lastmod>{{ page.publishedAt }}</lastmod>{% endif %}
       <changefreq>{{ page.sitemapChangeFreq }}</changefreq>
       <priority>{{ page.sitemapPriority }}</priority>
    </url>


### PR DESCRIPTION
## Type
Bugfix

Fixes an error when using the command on a website that has pages without `publishedAt` data:

```bash
$ php bin/console victoire:generate:sitemap --env=prod --no-debug -vvv

                                                           
  [Symfony\Component\Debug\Exception\FatalThrowableError]  
  Call to a member function format() on null               
                                                           

Exception trace:
 () at /var/www/preprod.wweeddoo.com/releases/20180430115502/vendor/victoire/victoire/Bundle/SitemapBundle/Domain/Export/SitemapExportHandler.php:94
 Victoire\Bundle\SitemapBundle\Domain\Export\SitemapExportHandler->serialize() at /var/www/preprod.wweeddoo.com/releases/20180430115502/vendor/victoire/victoire/Bundle/SitemapBundle/Command/GenerateCommand.php:42
 Victoire\Bundle\SitemapBundle\Command\GenerateCommand->execute() at 
```

## BC Break
NO