### PR TITLE
2.3 allow php 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "email": "contact@victoire.io"
     },
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.0",
         "a2lix/translation-form-bundle": "^2.1",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-migrations-bundle": "^1.2",


### PR DESCRIPTION
## Type
Feature

## Purpose
This PR removes a restriction on the minimal version of PHP.

This reverts a change in https://github.com/Victoire/victoire/commit/9414656a052fe9631f3e1c7c5b8848ce931bf985

## BC Break
NO