### PR TITLE
[WIP] Refactor LinkType: use select2 and cache pages tree

### DIFF
--- a/Bundle/FormBundle/Form/Type/LinkType.php
+++ b/Bundle/FormBundle/Form/Type/LinkType.php
@@ -122,22 +122,21 @@ class LinkType extends AbstractType
         switch ($linkType) {
             case Link::TYPE_VIEW_REFERENCE:
                 $locale = $locale ?: $this->requestStack->getCurrentRequest()->getLocale();
-                $form->add('viewReference', ChoiceType::class, [
-                    'label'                          => 'form.link_type.view_reference.label',
-                    'required'                       => true,
-                    'attr'                           => ['novalidate' => 'novalidate'],
-                    'placeholder'                    => 'form.link_type.view_reference.blank',
-                    'choices'                        => $this->viewReferenceRepository->getChoices($locale),
-                    'choices_as_values'              => true,
-                    'vic_vic_widget_form_group_attr' => ['class' => 'vic-form-group'],
-                ])->add('locale', ChoiceType::class, [
-                    'label'       => 'form.link_type.locale.label',
-                    'choices'     => array_combine($this->availableLocales, $this->availableLocales),
-                    'attr'        => [
-                        'data-refreshOnChange' => 'true',
-                        'data-target'          => $options['refresh-target'],
-                    ],
-                ]);
+                $choices = $this->viewReferenceRepository->getCachedChoices($locale);
+
+                $form
+                    ->add('viewReference', ViewReferenceType::class, [
+                        'locale'  => $locale,
+                        'choices' => $choices,
+                    ])
+                    ->add('locale', ChoiceType::class, [
+                        'label'       => 'form.link_type.locale.label',
+                        'choices'     => array_combine($this->availableLocales, $this->availableLocales),
+                        'attr'        => [
+                            'data-refreshOnChange' => 'true',
+                            'data-target'          => $options['refresh-target'],
+                        ],
+                    ]);
                 break;
             case Link::TYPE_ROUTE:
                 $form->add('route', null, [

--- a/Bundle/FormBundle/Form/Type/ViewReferenceType.php
+++ b/Bundle/FormBundle/Form/Type/ViewReferenceType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Victoire\Bundle\FormBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ViewReferenceType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'label'                          => 'form.link_type.view_reference.label',
+            'required'                       => true,
+            'attr'                           => [
+                'novalidate'                   => 'novalidate',
+                'tabindex'                     => '-1',
+                // classes are removed in choice_widget_collapsed so we use another attribute
+                'data-is-view-reference-field' => '1',
+            ],
+            'placeholder'                    => 'form.link_type.view_reference.blank',
+            'vic_vic_widget_form_group_attr' => ['class' => 'vic-form-group'],
+            'locale'                         => null,
+        ]);
+        parent::configureOptions($resolver);
+    }
+
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+}

--- a/Bundle/FormBundle/Resources/views/Form/fields.html.twig
+++ b/Bundle/FormBundle/Resources/views/Form/fields.html.twig
@@ -804,3 +804,11 @@
         {{ form_rest(form) }}
     </div>
 {% endblock %}
+
+{% block view_reference_widget %}
+    {{ block('choice_widget') }}
+
+    <script>
+        $vic('#{{ id }}').select2();
+    </script>
+{% endblock %}

--- a/Bundle/ViewReferenceBundle/Resources/doc/redis.md
+++ b/Bundle/ViewReferenceBundle/Resources/doc/redis.md
@@ -85,4 +85,4 @@ Class Methods:
 - getReferencesByParameters($parameters, $transform = true, $keepChildren = false)
 - getOneReferenceByParameters($parameters, $transform = true, $keepChildren = false)
 - hasReference()
-- getChoices($refId = null, $depth = 0)
+- getChoices($locale, $parentRefId = null, $refId = null, $depth = 0, $parentName = '')


### PR DESCRIPTION
## Type
Bugfix

This is an alternative to #1074 without the AJAX loading of values.

The modal takes longer to render **but** once it's loaded, the select2 are usable directly, even if they are laggy.

## Purpose
Fixes #1069

## BC Break
NO