### PR TITLE
[2.2] Fix error with settings roles

### DIFF
--- a/Bundle/PageBundle/Resources/views/Page/settings.html.twig
+++ b/Bundle/PageBundle/Resources/views/Page/settings.html.twig
@@ -19,10 +19,12 @@
                         {{ form_widget(form.translations) }}
                         {{ form_row(form.parent) }}
                         {{ form_row(form.template) }}
-                        {{ form_row(form.roles) }}
+                        {% if form.roles is defined %}
+                            {{ form_row(form.roles) }}
+                        {% endif %}
 
                         {% if form.locale is defined %}
-                        {{ form_row(form.locale) }}
+                            {{ form_row(form.locale) }}
                         {% endif %}
                     </div>
 


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Fixes an exception:

> Neither the property "roles" nor one of the methods "roles()", "getroles()"/"isroles()" or "__call()" exist and have public access in class "Symfony\Component\Form\FormView".
> 500 Internal Server Error - Twig_Error_Runtime 
>  in vendor/victoire/victoire/Bundle/PageBundle/Resources/views/Page/settings.html.twig at line 22  - 

This error is due to the fact that the `roles` field is added only if the user as the `ROLE_VICTOIRE_DEVELOPER` role: https://github.com/Victoire/victoire/blob/023e778c859699cc4992b5f05cb9b864c4e2f0e4/Bundle/CoreBundle/Form/ViewType.php#L126

An user with the `ROLE_VICTOIRE` role can access to this modal form, but an error is thrown if the user doesn't have the `ROLE_VICTOIRE_DEVELOPER` role.

## BC Break
NO