### PR TITLE
PageHelper: Fix PHPDoc

### DIFF
--- a/Bundle/PageBundle/Helper/PageHelper.php
+++ b/Bundle/PageBundle/Helper/PageHelper.php
@@ -172,10 +172,10 @@ class PageHelper
      * Generates a response from a page url.
      * If seo redirect, return target.
      *
-     * @param string $uri
-     * @param string $url
-     * @param        $locale
-     * @param null   $layout
+     * @param string      $uri
+     * @param string      $url
+     * @param             $locale
+     * @param string|null $layout
      *
      * @return Response
      */
@@ -233,8 +233,8 @@ class PageHelper
     /**
      * Generates a response from a page.
      *
-     * @param View $view
-     * @param null $layout
+     * @param View        $view
+     * @param string|null $layout
      *
      * @return Response
      */


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Fixes PHPDoc because it breaks the PHPStan analysis of a project that call one of these methods.

Error reported by PHPStan:

```
 ------ -------------------------------------------------------------------- 
  Line   src/AppBundle/Controller/AppController.php                      
 ------ -------------------------------------------------------------------- 
  40     Parameter #2 $layout of method                                      
         Victoire\Bundle\PageBundle\Helper\PageHelper::renderPage() expects  
         null, string given.                                                 
```

## BC Break
NO