### PR TITLE
force the good locale on sitemap generation command

### DIFF
--- a/Bundle/SitemapBundle/Domain/Export/SitemapExportHandler.php
+++ b/Bundle/SitemapBundle/Domain/Export/SitemapExportHandler.php
@@ -90,6 +90,8 @@ class SitemapExportHandler
             ->run();
         /** @var BasePage $page */
         foreach ($pages as $page) {
+            $page->setCurrentLocale($locale);
+            $this->entityManager->refresh($page);
             $page->translate($locale);
         }
 


### PR DESCRIPTION
## Type
Bugfix 

## Purpose
Fixes a mix of locales in the sitemap URLs when we use the `victoire:generate:sitemap` command.

## BC Break
NO
