### PR TITLE
raise symfony/swiftmailer-bundle dependancy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "symfony/monolog-bundle": "^3.1.0",
         "symfony/polyfill-apcu": "^1.0",
         "symfony/symfony": "^3.4,<3.4.5",
-        "symfony/swiftmailer-bundle": "^2.6.4",
+        "symfony/swiftmailer-bundle": "^2.6.4|^3.0",
         "symfony/twig-bundle": "~3.0",
         "troopers/alertify-bundle": "^3.0",
         "troopers/assetic-injector-bundle": "^1.1",


### PR DESCRIPTION
## Type
Bugfix

## Purpose
This PR allows to install more recent versions of swift mailer 

## BC Break
NO