### PR TITLE
MediaBundle need LiipImagine

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -237,6 +237,9 @@ fos_user_resetting:
 fos_js_routing:
     resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"
 
+_liip_imagine:
+    resource: "@LiipImagineBundle/Resources/config/routing.xml"
+    
 #Needs to be the last
 VictoireCoreBundle:
     resource: .


### PR DESCRIPTION
MediaBundle require LiipImagine to display image but routing is missing

## Type
Bugfix

## Purpose
Fixes thumbnail uri in Media Library

## BC Break
NO