### PR TITLE
fix liip_imagine config

### DIFF
--- a/Bundle/MediaBundle/Resources/config/liip_imagine.yml
+++ b/Bundle/MediaBundle/Resources/config/liip_imagine.yml
@@ -1,7 +1,6 @@
 liip_imagine:
     #cache_prefix: uploads/cache
     driver: gd
-    data_loader: filesystem
     #cache: no_cache
     #data_root: %kernel.root_dir%/../web
     #formats : ['jpg', 'jpeg','png', 'gif', 'bmp']


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Filesystem is already the default loader and this syntax make errors 

https://symfony.com/doc/2.0/bundles/LiipImagineBundle/data-loader/filesystem.html

![image](https://user-images.githubusercontent.com/16239924/50679509-01f11080-1004-11e9-94b2-0942530066c3.png)

## BC Break
NO
