### PR TITLE
increase meta description field

### DIFF
--- a/Bundle/SeoBundle/Entity/PageSeoTranslation.php
+++ b/Bundle/SeoBundle/Entity/PageSeoTranslation.php
@@ -32,8 +32,8 @@ class PageSeoTranslation
     /**
      * @var string
      *
-     * @ORM\Column(name="meta_description", type="string", length=255, nullable=true)
-     * @Assert\Length(max = 230)
+     * @ORM\Column(name="meta_description", type="string", length=320, nullable=true)
+     * @Assert\Length(max = 320)
      */
     protected $metaDescription;
 


### PR DESCRIPTION
## Type
feature

## Purpose
Google now allow dynamic meta description size. 320 char will be less prohibitive than 230
## BC Break
NO
