### PR TITLE
Fixing the path AppKernel path

### DIFF
--- a/doc/setup.md
+++ b/doc/setup.md
@@ -23,7 +23,7 @@ composer require victoire/victoire twig/twig:~2.0
 
 Register the following bundles in the `AppKernel`:
 
-`app/config/AppKernel.php`
+`app/AppKernel.php`
 ```php
 <?php
 use Symfony\Component\HttpKernel\Kernel;


### PR DESCRIPTION
Wrong path for AppKernel.php

## Type
Documentation

This PR improves documentation of setup

## BC Break
NO
