### PR TITLE
Fix/ci deprecation msg hidden

### DIFF
--- a/Bundle/CoreBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
+++ b/Bundle/CoreBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
@@ -9,11 +9,23 @@ class OverrideServiceCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $container->getDefinition('assetic.filter.cssrewrite')->setPublic(true);
-        $container->getDefinition('assetic.filter.less')->setPublic(true);
-        $container->getDefinition('assetic.filter.scss')->setPublic(true);
-        $container->getDefinition('assetic.filter_manager')->setPublic(true);
-        $container->getDefinition('assetic.asset_manager')->setPublic(true);
-        $container->getDefinition('victoire_core.entity_proxy.cache_driver')->setPublic(true);
+        if($container->hasDefinition('assetic.filter.cssrewrite')) {
+            $container->getDefinition('assetic.filter.cssrewrite')->setPublic(true);
+        }
+        if($container->hasDefinition('assetic.filter.less')) {
+            $container->getDefinition('assetic.filter.less')->setPublic(true);
+        }
+        if($container->hasDefinition('assetic.filter.scss')) {
+            $container->getDefinition('assetic.filter.scss')->setPublic(true);
+        }
+        if($container->hasDefinition('assetic.filter_manager')) {
+            $container->getDefinition('assetic.filter_manager')->setPublic(true);
+        }
+        if($container->hasDefinition('assetic.asset_manager')) {
+            $container->getDefinition('assetic.asset_manager')->setPublic(true);
+        }
+        if($container->hasDefinition('victoire_core.entity_proxy.cache_driver')) {
+            $container->getDefinition('victoire_core.entity_proxy.cache_driver')->setPublic(true);
+        }
     }
 }

--- a/Bundle/CoreBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
+++ b/Bundle/CoreBundle/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
@@ -9,22 +9,22 @@ class OverrideServiceCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if($container->hasDefinition('assetic.filter.cssrewrite')) {
+        if ($container->hasDefinition('assetic.filter.cssrewrite')) {
             $container->getDefinition('assetic.filter.cssrewrite')->setPublic(true);
         }
-        if($container->hasDefinition('assetic.filter.less')) {
+        if ($container->hasDefinition('assetic.filter.less')) {
             $container->getDefinition('assetic.filter.less')->setPublic(true);
         }
-        if($container->hasDefinition('assetic.filter.scss')) {
+        if ($container->hasDefinition('assetic.filter.scss')) {
             $container->getDefinition('assetic.filter.scss')->setPublic(true);
         }
-        if($container->hasDefinition('assetic.filter_manager')) {
+        if ($container->hasDefinition('assetic.filter_manager')) {
             $container->getDefinition('assetic.filter_manager')->setPublic(true);
         }
-        if($container->hasDefinition('assetic.asset_manager')) {
+        if ($container->hasDefinition('assetic.asset_manager')) {
             $container->getDefinition('assetic.asset_manager')->setPublic(true);
         }
-        if($container->hasDefinition('victoire_core.entity_proxy.cache_driver')) {
+        if ($container->hasDefinition('victoire_core.entity_proxy.cache_driver')) {
             $container->getDefinition('victoire_core.entity_proxy.cache_driver')->setPublic(true);
         }
     }


### PR DESCRIPTION
## Type
Bugfix

## Purpose
Since a previous PR which was making public some services to hide some useless deprecations messages, the CI was failing.

This PR is quite simple and comes simply to check if the concerned services are defined before trying to make them public